### PR TITLE
Consistency pass: correct parameter coverage stat and cross-link STATE-VARIABLES

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Tech stack is not yet decided. The methods and scope come first.
 - [x] 10 research analyses completed
 - [x] 38 data sources catalogued
 - [x] 348-cell parameter table created
-- [x] 122/348 cells pre-populated (35%)
+- [x] 120/348 parameter cells filled (34%) - 91 observed, 29 derived
 - [x] Primary reference repo selected (Strauss)
 - [x] Architecture adaptation brief written
 - [x] State-variable specification drafted

--- a/STATE-VARIABLES.md
+++ b/STATE-VARIABLES.md
@@ -1,8 +1,9 @@
 # NZ AI Policy Sandbox - State Variable Specification
 
 *Date: 2026-04-18*  
-*Status: Draft v1*  
-*Purpose: define the minimum state structure required for a defensible whole-economy policy sandbox*
+*Status: Locked - consumed by equation versions v0.1 and v0.2*  
+*Purpose: define the minimum state structure required for a defensible whole-economy policy sandbox*  
+*Downstream: [Model Equations v0.2](src/equations/model-equations-v0.2.pdf) (all 19 sectors); [Model Equations v0.1](src/equations/model-equations-v0.1.pdf) (Tier 1, historical)*
 
 ---
 


### PR DESCRIPTION
Small consistency pass across repo documentation ahead of v0.3 kickoff.

### Fixes

**README.md** - parameter coverage statistic
- Was: `122/348 cells pre-populated (35%)`
- Now: `120/348 parameter cells filled (34%) - 91 observed, 29 derived`
- The CSV actually contains 120 filled rows (91 observed + 29 derived), 2 gap, 226 unfilled.

**STATE-VARIABLES.md** - reflect downstream consumption
- Status: `Draft v1` -> `Locked - consumed by equation versions v0.1 and v0.2`
- Added downstream links to `model-equations-v0.2.pdf` (all 19 sectors) and `model-equations-v0.1.pdf` (Tier 1, historical)

### What I checked but left alone
- Dated fields (2026-04-17) on SCOPE/METHODS/FAQ/PAPER-OUTLINE/CONTRIBUTING - content is still accurate, bulk-touching dates would be noise
- `docs/critical-analysis.md` "first framing overreached" language is a backward-looking reframe document and correctly describes the journey
- 44% references - all properly contextualised as trust/readiness, not adoption
- Tier math (252 + 72 + 24 = 348) consistent across `data/required-data-catalogue.md` and the CSV
- `src/equations/README.md` and root README are already v0.2-aware