### PR TITLE
Draft: scenario specification and parameter registry schema (v0.1)

### DIFF
--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -1,0 +1,218 @@
+# NZ AI Policy Sandbox - Scenario Specification
+
+*Date: 2026-04-24*
+*Status: Draft v0.1*
+*Purpose: Define the policy archetypes the sandbox compares, expressed as concrete parameter perturbations against the locked state variables and equations.*
+*Upstream: [Project scope](SCOPE.md), [Methods note](METHODS.md), [State variables](STATE-VARIABLES.md), [Model equations v0.2](src/equations/model-equations-v0.2.pdf)*
+*Downstream: Simulation runs, sensitivity analysis, backtesting targets, paper comparison tables*
+
+---
+
+## 1. Purpose
+
+The sandbox's core question is whether aggregate AI policy, designed around a single national average, systematically produces worse outcomes than sector-targeted policy in New Zealand.
+
+Answering that question requires running the model under **comparable, concretely-specified policy archetypes**. Without a scenario specification, "aggregate vs targeted" is a slogan. With one, it is a reproducible experiment.
+
+This document defines:
+- the policy archetypes compared
+- the levers each archetype pulls
+- the parameter perturbations that operationalise each lever
+- the comparison baseline (status quo)
+- how outcomes are measured across archetypes
+
+It does **not** define preferred policy. The sandbox is deliberately agnostic. The scenarios described here are archetypes for structural comparison, not recommendations.
+
+---
+
+## 2. Design principles
+
+The scenario set follows five rules.
+
+### Rule 1 - Archetypes, not real policies
+Scenarios represent structural shapes of policy (who is targeted, what lever is used, how intensely), not specific NZ government initiatives. A real policy mix maps to a weighted combination of archetypes; it is not the archetype itself.
+
+### Rule 2 - Same budget envelope
+Scenarios compared head-to-head use the same aggregate fiscal cost envelope, scaled appropriately. A targeted scenario that spends five times more than the aggregate scenario is not a fair comparison; it is an argument for larger budgets.
+
+### Rule 3 - Levers map to state variables, not outputs
+Policy levers act on inputs to the model: capability \(K_s\), adoption friction, enabling capacity \(E\), labour adjustment \(L_s\). They do not prescribe productivity \(P_s\) or labour pressure outcomes directly. Outcomes emerge from the dynamics.
+
+### Rule 4 - Honest intensity
+Each scenario specifies a baseline intensity (plausible for NZ) and a stress intensity (upper bound of what could be committed). Running both reveals whether the archetype's advantage is robust to size.
+
+### Rule 5 - Time-bounded
+All scenarios run over the same simulation horizon (default 10 years) and specify policy duration explicitly. A one-off pulse and a sustained programme produce different dynamics; the specification distinguishes them.
+
+---
+
+## 3. The baseline scenario: status quo
+
+Every other scenario is compared against the **status quo baseline**: no new AI-specific policy lever applied, parameters held at their calibrated 2025 values, with natural dynamics evolving under existing economic conditions.
+
+**Parameter settings:**
+- No additional \(K_s\) uplift from capability investment
+- No adoption friction reduction
+- No additional enabling capacity \(E\) beyond baseline trend
+- No targeted labour adjustment support
+- Default sector growth rates, productivity drift, and labour turnover
+
+**Purpose:** provides the counterfactual against which every policy archetype is measured. Not a forecast; a reference trajectory.
+
+---
+
+## 4. Policy archetypes
+
+Three archetypes are defined for the initial comparison set. Additional archetypes may be added as the project matures, but these three are sufficient to answer the core question.
+
+### Archetype A: Aggregate policy
+
+**Shape:** A single policy intensity applied uniformly across all 19 sectors, designed around a national average assumption.
+
+**What it represents:** "One-size-fits-all" policy - broad AI adoption subsidies, generic training programmes, economy-wide capability funding without sector differentiation.
+
+**Levers:**
+- Uniform \(K_s\) capability uplift applied equally to all sectors
+- Uniform reduction in adoption friction across all sectors
+- No sector-specific \(L_s\) support
+
+**Parameter perturbations (baseline intensity):**
+
+| Lever | State variable | Perturbation | Duration |
+|---|---|---|---|
+| A.1 | \(K_s\) | +\(\delta_K\) for all \(s \in \{1,...,19\}\), where \(\delta_K = 0.05\) per year | Years 1-5 |
+| A.2 | Adoption friction | -\(\delta_f\) for all \(s\), where \(\delta_f = 0.10\) | Years 1-5 |
+| A.3 | \(E\) | +\(\delta_E\) where \(\delta_E = 0.10\) | Years 1-5 |
+
+**Parameter perturbations (stress intensity):** all perturbations × 2, duration extended to years 1-10.
+
+**Fiscal envelope:** calibrated to match a plausible NZ aggregate AI readiness programme budget (order of magnitude to be set during calibration).
+
+---
+
+### Archetype B: Targeted demand-side policy
+
+**Shape:** Policy intensity concentrated on sectors where the evidence suggests adoption is the binding constraint, not capability. Demand-side means the lever acts on adoption friction, not capability investment.
+
+**What it represents:** Sector-targeted AI diffusion initiatives - adoption subsidies, procurement preferences, sector-specific integration support for sectors already capable but under-adopting.
+
+**Levers:**
+- No uniform capability investment
+- Adoption friction reduction concentrated in "demand-limited" sectors
+- \(L_s\) support in sectors with high labour adjustment pressure
+
+**Parameter perturbations (baseline intensity):**
+
+| Lever | State variable | Perturbation | Duration | Targeted sectors |
+|---|---|---|---|---|
+| B.1 | Adoption friction | -\(\delta_f^B\) where \(\delta_f^B = 0.25\) | Years 1-5 | Demand-limited sectors (identified during calibration from \(A_s/K_s\) ratio below threshold) |
+| B.2 | \(L_s\) support | +\(\delta_L\) where \(\delta_L = 0.15\) | Years 1-5 | Sectors with top-quartile labour adjustment pressure |
+| B.3 | \(E\) | +\(\delta_E\) where \(\delta_E = 0.05\) | Years 1-5 | Sector-specific, weighted by GDP share |
+
+**Parameter perturbations (stress intensity):** intensities × 2, duration years 1-10.
+
+**Fiscal envelope:** matched to Archetype A total cost, distributed unevenly.
+
+**Sector selection criterion:** a sector is "demand-limited" if its adoption-to-capability ratio \(A_s / K_s < \tau_D\), where \(\tau_D\) is a threshold calibrated during parameter fitting. This definition must be documented in the calibration log when the scenario is run.
+
+---
+
+### Archetype C: Targeted supply-side policy
+
+**Shape:** Policy intensity concentrated on sectors where the evidence suggests capability is the binding constraint, not adoption. Supply-side means the lever acts on capability investment and enabling capacity, not adoption friction.
+
+**What it represents:** Sector-targeted AI capability building - skills investment, R&D support, enabling infrastructure (data, compute, standards) for sectors under-capable relative to their adoption potential.
+
+**Levers:**
+- Capability investment concentrated in "capability-limited" sectors
+- Enabling capacity \(E\) uplift weighted toward supporting those sectors
+- No direct adoption friction reduction
+
+**Parameter perturbations (baseline intensity):**
+
+| Lever | State variable | Perturbation | Duration | Targeted sectors |
+|---|---|---|---|---|
+| C.1 | \(K_s\) | +\(\delta_K^C\) where \(\delta_K^C = 0.12\) per year | Years 1-5 | Capability-limited sectors (identified during calibration from \(A_s/K_s\) ratio above threshold) |
+| C.2 | \(E\) | +\(\delta_E^C\) where \(\delta_E^C = 0.20\) | Years 1-5 | Economy-wide but biased toward capability-limited sectors |
+| C.3 | \(L_s\) support | +\(\delta_L\) where \(\delta_L = 0.10\) | Years 1-5 | Sectors with active capability transitions |
+
+**Parameter perturbations (stress intensity):** intensities × 2, duration years 1-10.
+
+**Fiscal envelope:** matched to Archetype A total cost.
+
+**Sector selection criterion:** a sector is "capability-limited" if \(A_s / K_s > \tau_C\), where \(\tau_C\) is a threshold calibrated during parameter fitting.
+
+---
+
+## 5. Outcome measures
+
+Each scenario produces a trajectory for every state variable in every sector over the simulation horizon. For comparison purposes, the following aggregate outcome measures are computed:
+
+### Primary outcomes
+
+| Outcome | Definition | Why it matters |
+|---|---|---|
+| Whole-economy productivity gain | \(\sum_s w_s \cdot \Delta P_s(T)\), where \(w_s\) is sector GDP weight and \(T\) is horizon end | Primary economic outcome. Weighted by sector size so whole-economy effect is honest. |
+| Adoption spread | Variance of \(A_s(T)\) across sectors | Reveals whether the policy left some sectors behind. Lower variance is not automatically better; uniformity at a low level is bad. Interpretation depends on level. |
+| Labour adjustment cost | \(\sum_s \int_0^T L_s(t) \, dt\) | Cumulative labour pressure, integrated over time. Proxy for social disruption cost. |
+| Enabling capacity drawdown | \(1 - E(T) / E(0)\) | Whether the policy overstretched the shared enabling layer. Positive values indicate constraint. |
+
+### Secondary outcomes
+
+- Per-sector productivity gain at horizon end (19 values)
+- Time to median adoption (year at which \(A_s = 0.5\) first achieved per sector)
+- Capability-adoption gap evolution (\(A_s - K_s\) over time)
+- Dispersion in outcomes across sectors (Gini of \(P_s(T)\))
+
+### Honest outcome framing
+
+No scenario is declared "best" on a single metric. The point of the sandbox is to reveal tradeoffs. A scenario with higher whole-economy productivity but larger labour adjustment cost is a different policy from one with lower productivity but smoother labour dynamics. The paper reports all outcomes; it does not collapse them into a single index.
+
+---
+
+## 6. Scenario runs
+
+The initial comparison set runs nine configurations:
+
+| Run | Archetype | Intensity | Duration |
+|---|---|---|---|
+| 1 | Baseline (status quo) | - | 10 years |
+| 2 | A - Aggregate | Baseline | Years 1-5 |
+| 3 | A - Aggregate | Stress | Years 1-10 |
+| 4 | B - Targeted demand-side | Baseline | Years 1-5 |
+| 5 | B - Targeted demand-side | Stress | Years 1-10 |
+| 6 | C - Targeted supply-side | Baseline | Years 1-5 |
+| 7 | C - Targeted supply-side | Stress | Years 1-10 |
+| 8 | Mixed B+C | Baseline | Years 1-5 |
+| 9 | Mixed B+C | Stress | Years 1-10 |
+
+Runs 8 and 9 combine demand-side and supply-side targeting at half-intensity each, under the same total fiscal envelope. This tests whether hybrid targeting outperforms pure targeting.
+
+Every run is repeated across the Monte Carlo parameter ensemble defined in the uncertainty quantification plan (to be drafted).
+
+---
+
+## 7. What this specification does not cover
+
+- **Distributional effects within sectors.** The sandbox operates at sector level; intra-sector distribution (e.g. large firms vs SMEs within Manufacturing) is out of scope for v1.
+- **Regional variation.** Sectors are national; regional differences are not modelled.
+- **Transition pathways.** Scenarios specify end-state lever settings, not the political or implementation pathway that would deliver them.
+- **Second-order fiscal feedback.** Tax revenue changes from productivity gains are not fed back into the enabling capacity budget.
+- **International spillovers.** NZ is modelled as a closed system for v1.
+
+These limitations are explicit by design. The sandbox's value is structural comparison under bounded assumptions, not comprehensive economic forecasting.
+
+---
+
+## 8. Revisions
+
+### 2026-04-24 - Initial draft (v0.1)
+- Three archetypes defined: A (aggregate), B (targeted demand-side), C (targeted supply-side)
+- Baseline and stress intensities specified
+- Nine-run initial comparison set
+- Outcome measures defined
+- Awaiting validation against equations v0.2 during first simulation build
+
+---
+
+*See also: [PAPER-OUTLINE.md](PAPER-OUTLINE.md) for how scenario comparison feeds the paper's findings section; [METHODS.md](METHODS.md) for the methodological posture behind scenario framing.*

--- a/registry/REGISTRY-SCHEMA.md
+++ b/registry/REGISTRY-SCHEMA.md
@@ -1,0 +1,312 @@
+# Parameter Registry Schema
+
+*Date: 2026-04-24*
+*Status: Draft v0.1*
+*Purpose: Define a structured parameter registry that makes every cell traceable to source, date, method, and confidence. Enables calibration, sensitivity analysis, and external review without CSV archaeology.*
+*Upstream: [data/sector-parameter-table.csv](../data/sector-parameter-table.csv) (current flat form), [Sources catalogue](../docs/data-source-catalogue.md), [State variables](../STATE-VARIABLES.md)*
+*Downstream: Simulation code (v0.3), sensitivity analysis, calibration log, paper Appendix C*
+
+---
+
+## 1. Problem this solves
+
+The current parameter store is a single CSV with 348 rows. It works for an initial inventory but breaks down under the following uses:
+
+1. **Traceability** - when a simulation output looks wrong, there is no structured path from the output to the parameter, to the source, to the method that produced the value.
+2. **Uncertainty** - each cell has a single value. The model needs distributions (or at minimum ranges), not point estimates.
+3. **Provenance chain** - sources are named as strings. There is no link from parameter to a structured source record, to a document or URL, to a date of access.
+4. **Versioning** - updating a parameter loses the old value. There is no history of when and why a number changed.
+5. **Derived parameters** - some parameters are derived from others (e.g. sector-weighted averages). The CSV does not record the derivation.
+6. **Contributor workflow** - an external reviewer cannot propose a parameter change without rewriting the CSV cell.
+
+A structured registry fixes these one by one.
+
+---
+
+## 2. Schema
+
+Each parameter is a record. Records are stored as YAML (one file per sector, or one file per parameter group - see Section 6). The registry as a whole is the set of all records.
+
+### 2.1 Record structure
+
+```yaml
+# Example record: sector S01 Agriculture, parameter K1 (absorptive capability baseline)
+id: S01.K1
+sector:
+  id: S01
+  name: Agriculture
+  tier: 1
+  anzsic_code: A
+parameter:
+  code: K1
+  group: "Absorptive capability"
+  state_variable: "K_s"
+  name: "Absorptive capability baseline (t=0)"
+  description: >
+    Initial condition for sector absorptive capability K_s at simulation start (t=0).
+    Dimensionless, bounded [0,1]. Represents sector's readiness to absorb AI capability
+    given current skills, data, and management practices.
+  unit: "dimensionless [0,1]"
+  required_for_v1: true
+value:
+  current: 0.42
+  range:
+    low: 0.35
+    high: 0.50
+    type: "plausible_range"  # plausible_range | 90_ci | expert_bounds
+  distribution:
+    shape: "beta"
+    params: {alpha: 4.2, beta: 5.8}
+    notes: "Calibrated to midpoint 0.42, spread reflects cross-study variance in adoption readiness estimates"
+status: filled                   # filled | partial | open | disputed
+evidence_class: derived          # observed | derived | expert | placeholder
+confidence: medium               # high | medium | low
+method: >
+  Weighted average of (1) Stats NZ Business Operations Survey AI readiness scores 2024,
+  (2) AI Forum Business Productivity Report Sep 2024 sector rows for Agriculture,
+  (3) OECD Productivity Indicators agri-technology adoption 2024.
+  Weights: 0.5 / 0.3 / 0.2 reflecting sample representativeness.
+sources:
+  primary:
+    id: src.statsnz.bos.2024
+    citation: "Stats NZ Business Operations Survey 2024"
+    url: "https://www.stats.govt.nz/..."
+    accessed: "2026-04-10"
+  secondary:
+    - id: src.aiforum.productivity.2024-09
+      citation: "AI Forum NZ Business Productivity Report, September 2024"
+      url: "https://..."
+      accessed: "2026-04-12"
+    - id: src.oecd.productivity.2024
+      citation: "OECD Productivity Indicators 2024, Agri-technology adoption"
+      url: "https://..."
+      accessed: "2026-04-11"
+history:
+  - date: "2026-04-10"
+    value: 0.40
+    note: "Initial placeholder from OECD only"
+    author: "ck"
+  - date: "2026-04-18"
+    value: 0.42
+    note: "Updated after Stats NZ BOS 2024 released, weighted average applied"
+    author: "ck"
+dependencies: []                  # list of other parameter IDs this value depends on
+used_by:
+  - equation: "eq.K.dynamics"
+    role: "initial_condition"
+notes: >
+  Cross-check against upcoming AI Forum sector-level cuts expected Q2 2026.
+  If that data confirms current value within ±0.05, upgrade confidence to high.
+```
+
+### 2.2 Required fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Format: `{sector_id}.{param_code}` (e.g. `S01.K1`). Globally unique. |
+| `sector` | yes | Nested object: id, name, tier, anzsic_code |
+| `parameter` | yes | Nested object: code, group, state_variable, name, description, unit, required_for_v1 |
+| `value.current` | yes (unless status=open) | Point estimate for simulation. |
+| `value.range` | yes when status=filled | Plausible range for sensitivity analysis. |
+| `value.distribution` | optional | Required before full Monte Carlo runs. Shape + params. |
+| `status` | yes | filled / partial / open / disputed |
+| `evidence_class` | yes | observed / derived / expert / placeholder |
+| `confidence` | yes | high / medium / low |
+| `method` | yes (unless status=open) | How the value was produced. |
+| `sources.primary` | yes when evidence_class in {observed, derived} | Structured source reference. |
+| `sources.secondary` | optional | List of structured source references. |
+| `history` | yes | List of {date, value, note, author}. At least one entry. |
+| `dependencies` | optional | List of parameter IDs. |
+| `used_by` | optional | List of {equation, role} pairs documenting where in the model this parameter enters. |
+| `notes` | optional | Free text. |
+
+### 2.3 Enumerated values
+
+**status:**
+- `filled` - current value set, range defined, method documented, suitable for simulation.
+- `partial` - current value set but range or method incomplete. Usable with caveats.
+- `open` - no current value yet. Calibration pending.
+- `disputed` - sources conflict materially. Notes must explain the dispute.
+
+**evidence_class:**
+- `observed` - directly measured in a source (e.g. GDP from Stats NZ).
+- `derived` - computed from observed values using a documented method.
+- `expert` - not observable in available data, assigned based on analyst judgement from literature.
+- `placeholder` - assigned for model stability but not calibrated. Sensitivity analysis must flag these.
+
+**confidence:**
+- `high` - primary source is authoritative, current, and sector-specific. Range is narrow.
+- `medium` - sources are credible but not directly sector-specific, or range is wide.
+- `low` - sources are thin, proxies used, or method requires significant assumption. Must appear in sensitivity screening.
+
+---
+
+## 3. Source records
+
+Sources are first-class objects referenced by ID. Defined once in `registry/sources.yaml`, referenced from parameter records. Prevents string-matching on citation fields and makes source updates propagate.
+
+```yaml
+# registry/sources.yaml
+sources:
+  - id: src.statsnz.bos.2024
+    citation: "Stats NZ Business Operations Survey 2024"
+    publisher: "Stats NZ"
+    date: "2024-12-01"
+    type: "survey"
+    url: "https://www.stats.govt.nz/information-releases/business-operations-survey-2024"
+    accessed: "2026-04-10"
+    selection_bias: "nationally-representative, stratified sample, weighted"
+    methodology_notes: >
+      N=7,500, annual, sector-weighted. AI-specific module added 2024.
+    tags: ["adoption", "capability", "nz-official"]
+  - id: src.aiforum.productivity.2024-09
+    citation: "AI Forum NZ Business Productivity Report, September 2024"
+    publisher: "AI Forum NZ"
+    date: "2024-09-01"
+    type: "industry-report"
+    url: "https://aiforum.org.nz/..."
+    accessed: "2026-04-12"
+    selection_bias: "self-selected, opt-in, AI-interested network"
+    methodology_notes: >
+      N~400, online survey of AI Forum members and extended network.
+    tags: ["adoption", "productivity", "barriers", "industry"]
+```
+
+Tagging source records enables queries like "show all parameters derived from nz-official sources" - useful for the paper's evidence base section.
+
+---
+
+## 4. Directory layout
+
+```
+aips/
+  registry/
+    sources.yaml                  # all source records
+    parameters/
+      S01-agriculture.yaml        # all parameters for sector S01
+      S02-mining.yaml
+      S03-manufacturing.yaml
+      ...
+      S19-other-services.yaml
+    system/
+      E.yaml                      # system-level parameters (shared enabling capacity)
+      global.yaml                 # simulation-wide constants
+    schema/
+      parameter.schema.json       # JSON Schema for record validation
+      source.schema.json
+  scripts/
+    registry_load.py              # load all YAML into unified in-memory model
+    registry_validate.py          # schema + cross-reference validation
+    registry_export_csv.py        # export to flat CSV for external review
+    registry_import_csv.py        # one-time migration from current CSV
+```
+
+Splitting parameters by sector keeps individual files under ~500 lines and aligns with how calibration actually happens (one sector at a time).
+
+---
+
+## 5. Loader interface
+
+Simulation code consumes the registry through a single loader:
+
+```python
+from aips.registry import Registry
+
+reg = Registry.load("registry/")
+
+# Point estimate for simulation run
+k_s01_0 = reg.parameter("S01.K1").value
+
+# Range for sensitivity analysis
+k_s01_range = reg.parameter("S01.K1").range  # (low, high)
+
+# Distribution sample for Monte Carlo
+sample = reg.parameter("S01.K1").sample(n=1000, seed=42)
+
+# All parameters for a sector
+ag_params = reg.sector("S01").all()
+
+# All parameters entering a specific equation
+k_eq_params = reg.used_by("eq.K.dynamics")
+
+# Filter by status/confidence
+low_conf_filled = reg.filter(status="filled", confidence="low")
+```
+
+The loader validates against the JSON Schema on load. Any broken record halts simulation with a clear error pointing to the file and line.
+
+---
+
+## 6. Migration from the current CSV
+
+The existing `data/sector-parameter-table.csv` has 348 rows. Migration is a one-time conversion, not an ongoing dual-maintenance problem.
+
+### Steps
+
+1. **Schema lock.** Finalise `parameter.schema.json` and `source.schema.json`. Review with one external reader if possible.
+2. **Source extraction.** Walk the CSV's `primary_source` and `secondary_source` columns. Deduplicate. Write `registry/sources.yaml`. Assign source IDs.
+3. **Parameter migration.** For each CSV row, construct a YAML record using the column mapping below. Initial `history` entry is `{date: 2026-04-24, value: <csv value>, note: "Migrated from sector-parameter-table.csv", author: "ck"}`.
+4. **Range inference.** For rows with no explicit range, assign `value.range` using a default rule (±20% for `observed`, ±40% for `derived`, ±60% for `expert`, ±80% for `placeholder`). Record the inference method in notes. These are starting ranges only; sensitivity analysis will refine.
+5. **Validation.** Run `registry_validate.py` - must pass before CSV is considered retired.
+6. **CSV retirement.** Move current CSV to `data/archive/sector-parameter-table-20260424.csv`. Replace with auto-generated export from the registry (one-way, for external reviewers who want a flat view).
+
+### Column mapping (CSV → YAML)
+
+| CSV column | YAML path |
+|---|---|
+| `sector_id` | `sector.id` |
+| `sector_name` | `sector.name` |
+| `tier` | `sector.tier` (integer) |
+| `param_code` | `parameter.code` |
+| `param_group` | `parameter.group` |
+| `param_name` | `parameter.name` |
+| `unit` | `parameter.unit` |
+| `required_for_v1` | `parameter.required_for_v1` (boolean) |
+| `value` | `value.current` (parse numeric where possible; text preserved in `notes`) |
+| `status` | `status` |
+| `evidence_class` | `evidence_class` |
+| `confidence` | `confidence` |
+| `primary_source` | `sources.primary` via source-table lookup |
+| `secondary_source` | `sources.secondary` via source-table lookup |
+| `notes` | `notes` |
+
+---
+
+## 7. Contributor workflow
+
+External contributors proposing a parameter change do the following:
+
+1. Edit the relevant `registry/parameters/SXX-*.yaml` file.
+2. Update `value.current` (and `range` / `distribution` if applicable).
+3. Append a new entry to `history` with date, old→new value, rationale, author.
+4. Update `method`, `sources`, `confidence` as needed.
+5. Open a PR. The validator runs on PR CI.
+6. The AIPS lead reviews the change against the evidence and merges (or requests revision).
+
+This makes "a Stats NZ analyst can propose a calibration update without reading any Python" a reachable goal.
+
+---
+
+## 8. What this schema does not cover yet
+
+- **Equation parameters as first-class records.** Currently the registry covers sector-indexed parameters and system-level parameters. Model coefficients (damping rates, coupling strengths in the ODEs) are not yet in the schema. They should be, before v0.3 calibration begins.
+- **Scenario lever parameters.** The perturbation sizes in [SCENARIOS.md](../SCENARIOS.md) are currently prose. They should be defined as parameter records with the same schema.
+- **Calibration provenance for derived values.** When a value is updated by an automated calibration run, the `history` entry should capture the calibration target, the optimiser used, and the fit metric. The schema supports free-text notes; a structured subfield for calibration runs would be cleaner.
+
+These are v0.2 schema extensions. Current v0.1 is sufficient to migrate the CSV and begin v0.3 calibration.
+
+---
+
+## 9. Revisions
+
+### 2026-04-24 - Initial draft (v0.1)
+- YAML-based, one file per sector, one file per system-level parameter
+- Source records as first-class objects in `sources.yaml`
+- Required fields specified, enumerated values defined
+- Loader interface sketched
+- Migration plan for current CSV documented
+- Awaiting schema lock and first migration run
+
+---
+
+*See also: [data/sector-parameter-table.csv](../data/sector-parameter-table.csv) for current flat store; [STATE-VARIABLES.md](../STATE-VARIABLES.md) for the variable definitions parameters attach to; [SCENARIOS.md](../SCENARIOS.md) for how scenario perturbations will slot into the registry once schema v0.2 is in.*


### PR DESCRIPTION
## What this adds

**`SCENARIOS.md`** (218 lines) - three policy archetypes spec'd against the locked state variables:

- Aggregate (broad GDP-share allocation)
- Targeted demand-side
- Targeted supply-side

Each defined with concrete parameter perturbations, baseline + stress intensities, a 9-run initial comparison set, and outcome measures.

**`registry/REGISTRY-SCHEMA.md`** (312 lines) - YAML parameter registry schema with per-cell provenance, range, distribution, history, source references. Includes directory layout, loader interface contract, and migration plan from the current CSV to the registry.

## Status

Both are **v0.1 drafts**. They build directly on top of v0.3 (merged in #7) and the locked state variables in `STATE-VARIABLES.md`.

## Suggested next steps after merge

1. Review and refine scenario definitions
2. Implement registry migration (CSV -> YAML)
3. First v0 simulation against the 9-run comparison set