### PR TITLE
Draft scenario specification and parameter registry schema (#8)

### DIFF
--- a/.github/CONTRIBUTING-STYLE.md
+++ b/.github/CONTRIBUTING-STYLE.md
@@ -3,6 +3,6 @@
 ## Language and Style
 
 - **NZ English** - use NZ spelling throughout (e.g. colour, organisation, programme, licence, analyse, behaviour, modelling). Not US English.
-- **No em-dashes** - do not use the em-dash character. Use spaced hyphens (` - `) instead. This applies to all content: markdown, code comments, documentation, and commit messages.
+- **Use spaced hyphens** - (` - `). This applies to all content: markdown, code comments, documentation, and commit messages.
 
 These rules apply to all contributions to this repository.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read specs/001-ai-policy-sandbox-app/plan.md
+<!-- SPECKIT END -->
+
+# Repository Instructions
+
+This repository and project is the New Zealand AI Policy Sandbox: a transparent, NZ sector-calibrated policy sandbox for comparing AI policy tradeoffs under uncertainty. Treat it as a policy comparison framework and structured evidence synthesis, not as a forecasting engine, black-box simulator, definitive adoption ranking, or source of exact GDP and employment predictions.
+
+## Read First
+
+- Start with `README.md` for the project framing, research question, current status, and evidence base.
+- Treat `.specify/memory/constitution.md` as the governing Spec Kit constitution for feature planning, tasks, implementation, and review.
+- For scope and modelling posture, read `SCOPE.md`, `METHODS.md`, and `STATE-VARIABLES.md` before changing model structure.
+- For policy scenarios, read `SCENARIOS.md` before changing scenario language, run definitions, or outcome measures.
+- For evidence and calibration work, read `docs/provenance-analysis.md`, `data/required-data-catalogue.md`, and `registry/REGISTRY-SCHEMA.md`.
+- For equation work, read `src/equations/README.md` and the current equation source before editing LaTeX.
+
+## Project Guardrails
+
+- Preserve the policy sandbox framing. The model supports comparative reasoning under uncertainty; do not present outputs as forecasts or precise future claims.
+- Prefer simple, maintainable designs. Add abstractions, services, persistence, or model dimensions only when the need is documented and a simpler option is insufficient.
+- Prefer functional programming patterns for model, content, validation, and export logic: pure transformations, immutable inputs, deterministic outputs, and isolated side effects.
+- Keep implementation code type safe. Use explicit schemas or typed contracts for structured data and validate repo-backed content before use.
+- Keep user-facing UX uniform across navigation, controls, terminology, caveats, responsive layout, and accessibility patterns.
+- Whole-economy coverage is mandatory. Aggregate-policy comparisons must cover all 19 ANZSIC Level 1 sectors, not only the 9 Tier 1 narrative sectors.
+- Respect the tiered structure: Tier 1 has full explanatory sectors, Tier 2 has simplified sectors, and Tier 3 closes the residual economy denominator.
+- Treat `STATE-VARIABLES.md` as locked unless the user explicitly asks to revisit the state space. The core structure is adoption maturity, absorptive capability, realised productivity effect, labour adjustment pressure, and national enabling capacity.
+- Keep one mechanism per layer. Avoid double counting capability, productivity, labour pressure, trust, or enabling effects across multiple variables.
+- Prefer the simplest model that answers the policy question credibly. Do not add firm-level agents, regional variation, fiscal feedback, international spillovers, or distributional analysis unless the scope changes.
+
+## Evidence And Provenance
+
+- Distinguish evidence classes explicitly: observed, derived, expert, placeholder, or assumed.
+- For parameters and factual claims, record source, method, confidence, access date, and selection bias where available.
+- Treat the 32%-87% NZ AI adoption range as core context. The point is methodological fragmentation, not choosing a single national adoption number.
+- When NZ-specific evidence is thin, use Stats NZ baselines first, then NZ policy or industry context, then international benchmarks as derived inputs with caveats.
+- Do not make untraceable parameter changes. Future parameter work should align with the structured YAML registry direction in `registry/REGISTRY-SCHEMA.md`.
+
+## Scenarios And Claims
+
+- Scenarios are archetypes for structural comparison, not policy recommendations.
+- Compare like with like: scenarios compared head-to-head should use the same aggregate budget envelope and simulation horizon unless the task explicitly says otherwise.
+- Report tradeoffs across productivity, adoption spread, labour adjustment pressure, and enabling capacity. Do not collapse the sandbox into a single best-policy score.
+- Avoid exact GDP forecasts, exact job-loss counts, definitive sector rankings, or definitive national adoption rates unless the supporting document explicitly warrants that claim.
+
+## Artefact Guidance
+
+- Markdown and documentation must use NZ English and spaced hyphens (` - `), following `.github/CONTRIBUTING-STYLE.md`.
+- State assumptions and caveats plainly. If evidence is weak, label it weak.
+- Equation versions `v0.1` and `v0.2` are historical. `v0.3` is the current calibrated specification; do not rewrite older versions unless explicitly asked.
+- Build equations with `cd src/equations && make`. Use `make v02` or `make v01` only for historical versions.
+- No simulation tech stack is locked yet. Before adding implementation code, align with the equation specification, scenario specification, registry schema, and any current Spec Kit plan.
+- Existing Speckit agents and prompts are workflow tooling. Do not treat their generic templates as domain rules for this project.
+
+## Unresolved Conventions
+
+Ask or document a decision before inventing conventions for simulation language, package management, result storage, calibration QA, run versioning, peer review, sensitivity-analysis file layout, or registry validation commands.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ Thumbs.db
 *.log
 *.out
 *.toc
+
+# Speck kit files
+.specify/
+
+.github/agents/
+.github/prompts/

--- a/specs/001-ai-policy-sandbox-app/checklists/requirements.md
+++ b/specs/001-ai-policy-sandbox-app/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Interactive AI Policy Sandbox App
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-03  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed on 2026-05-03. No unresolved clarification markers or blocking quality issues remain.
+- The specification is ready for `/speckit.plan`; `/speckit.clarify` remains optional if stakeholders want to narrow v1 scope further.

--- a/specs/001-ai-policy-sandbox-app/contracts/data-contracts.md
+++ b/specs/001-ai-policy-sandbox-app/contracts/data-contracts.md
@@ -1,0 +1,149 @@
+# Contracts: Interactive AI Policy Sandbox App
+
+The showcase MVP has no public write API and no saved public runs. Its primary contracts are repo-backed content contracts, comparison state contracts, and static summary export contracts.
+
+## Published Content Contract
+
+Authoritative app content is loaded from reviewed YAML/JSON files in the repository and validated with Zod before use.
+
+Required shape:
+
+```ts
+type PublishedContentVersion = {
+  id: string;
+  sourceRevision: string;
+  publishedAt: string;
+  summary: string;
+  includes: string[];
+};
+```
+
+Contract rules:
+
+- `id` and `sourceRevision` are required for every public comparison.
+- Only reviewed repository content can produce a Published Content Version.
+- Displayed comparisons and exports must identify the Published Content Version.
+
+## Scenario Contract
+
+```ts
+type PolicyScenario = {
+  id: string;
+  name: string;
+  archetype: 'status-quo' | 'aggregate' | 'targeted-demand-side' | 'targeted-supply-side' | 'mixed-targeted';
+  description: string;
+  defaultBudgetEnvelope: number | string;
+  defaultHorizonYears: number;
+  assumptions: string[];
+  caveats: string[];
+  evidenceRefs: string[];
+};
+```
+
+Contract rules:
+
+- Scenario text must frame scenarios as archetypes, not recommendations.
+- Budget and horizon defaults are required.
+- Evidence references must resolve to Evidence Records.
+
+## Sector Contract
+
+```ts
+type Sector = {
+  id: string;
+  anzsicCode: string;
+  name: string;
+  tier: 1 | 2 | 3;
+  baselineAssumptions: string[];
+  evidenceRefs: string[];
+};
+```
+
+Contract rules:
+
+- Aggregate comparison data must include exactly the 19 ANZSIC Level 1 sectors.
+- Tier information is required for every sector.
+- Tier 2 and Tier 3 sectors cannot be omitted from aggregate totals.
+
+## Evidence Record Contract
+
+```ts
+type EvidenceRecord = {
+  id: string;
+  evidenceClass: 'observed' | 'derived' | 'expert' | 'placeholder' | 'assumed';
+  source?: string;
+  method?: string;
+  confidence?: 'high' | 'medium' | 'low';
+  accessDate?: string;
+  selectionBias?: string;
+  notes?: string;
+};
+```
+
+Contract rules:
+
+- Evidence class is required.
+- Observed and derived records should include source and method.
+- Placeholder, assumed, low-confidence, or missing evidence must be surfaced in UI and exports.
+
+## Approved Control Contract
+
+```ts
+type ApprovedControl = {
+  id: string;
+  type: 'scenario-selection' | 'budget-envelope' | 'time-horizon' | 'uncertainty-range';
+  label: string;
+  description: string;
+  defaultValue: unknown;
+  allowedRange?: unknown;
+  appliesTo: string[];
+  caveat: string;
+};
+```
+
+Contract rules:
+
+- Public controls are limited to the listed `type` values.
+- Public controls must not expose sector-specific parameter editing.
+- Controls must be published through reviewed repo content before appearing publicly.
+
+## Public Comparison State Contract
+
+```ts
+type PublicComparisonState = {
+  selectedScenarioIds: string[];
+  budgetEnvelope: number | string;
+  horizonYears: number;
+  approvedControlValues: Record<string, unknown>;
+  publishedContentVersionId: string;
+  createdInSessionAt: string;
+};
+```
+
+Contract rules:
+
+- State is browser-session-only for public users.
+- State must not be posted to a server for persistence.
+- Comparisons must flag inconsistent budget, horizon, sector coverage, or scenario assumptions.
+
+## Static Summary Export Contract
+
+```ts
+type StaticSummaryExport = {
+  title: string;
+  generatedAt: string;
+  publishedContentVersionId: string;
+  selectedScenarios: Array<{ id: string; name: string }>;
+  exploratoryInputs: Record<string, unknown>;
+  tradeoffSummary: string;
+  sensitivityNotes: string[];
+  evidenceCaveats: string[];
+  nonForecastStatement: string;
+};
+```
+
+Contract rules:
+
+- Export must include selected scenarios, exploratory inputs, published content version, tradeoffs, uncertainty notes, and caveats.
+- Export must include non-forecast framing.
+- Export must not imply a definitive recommendation, exact GDP prediction, exact employment prediction, or definitive sector ranking.

--- a/specs/001-ai-policy-sandbox-app/data-model.md
+++ b/specs/001-ai-policy-sandbox-app/data-model.md
@@ -1,0 +1,209 @@
+# Data Model: Interactive AI Policy Sandbox App
+
+## Entity: Published Content Version
+
+**Purpose**: Identifies the reviewed repository content consumed by the public application.
+
+**Fields**:
+
+- `id`: stable version identifier, such as a release tag, commit SHA, or generated content version.
+- `sourceRevision`: repository revision used to build the content.
+- `publishedAt`: ISO date for publication.
+- `summary`: short description of the published content set.
+- `includes`: list of included scenario, sector, evidence, and registry content files.
+
+**Relationships**:
+
+- Owns many Policy Scenarios, Sectors, Evidence Records, and Approved Controls.
+- Referenced by every Comparison Run and Static Summary Export.
+
+**Validation Rules**:
+
+- Must be present before public comparisons are shown.
+- Must identify a source revision.
+- Must not include unreviewed analyst draft content.
+
+## Entity: Policy Scenario
+
+**Purpose**: Represents a scenario archetype available for comparison.
+
+**Fields**:
+
+- `id`: stable scenario identifier.
+- `name`: display name.
+- `archetype`: status quo, aggregate, targeted demand-side, targeted supply-side, or mixed targeted.
+- `description`: policy-neutral scenario description.
+- `defaultBudgetEnvelope`: numeric or categorical budget envelope.
+- `defaultHorizonYears`: default comparison horizon.
+- `assumptions`: list of scenario-level assumptions.
+- `caveats`: non-forecast and evidence caveats.
+- `evidenceRefs`: Evidence Record identifiers.
+
+**Relationships**:
+
+- Used by Comparison Runs.
+- References Evidence Records.
+
+**Validation Rules**:
+
+- Must preserve scenario-as-archetype language.
+- Must not describe a scenario as a recommendation.
+- Must declare default budget and horizon for like-for-like comparison.
+
+## Entity: Sector
+
+**Purpose**: Represents one ANZSIC Level 1 sector in the whole-economy model denominator.
+
+**Fields**:
+
+- `id`: stable sector identifier.
+- `anzsicCode`: ANZSIC Level 1 code.
+- `name`: sector name.
+- `tier`: 1, 2, or 3.
+- `baselineAssumptions`: sector assumptions used in comparisons.
+- `evidenceRefs`: Evidence Record identifiers.
+
+**Relationships**:
+
+- Used in aggregate comparison coverage checks.
+- References Evidence Records.
+
+**Validation Rules**:
+
+- Aggregate comparison content must include all 19 ANZSIC Level 1 sectors.
+- Tier 1 sectors must support full explanatory detail.
+- Tier 2 and Tier 3 sectors must be included in whole-economy totals even if simplified.
+
+## Entity: Outcome Dimension
+
+**Purpose**: Defines the dimensions used to compare policy tradeoffs.
+
+**Fields**:
+
+- `id`: stable outcome identifier.
+- `name`: productivity, adoption spread, labour adjustment pressure, or national enabling capacity.
+- `description`: plain-language description.
+- `directionality`: whether higher values are beneficial, costly, or contextual.
+- `caveats`: interpretation notes.
+
+**Relationships**:
+
+- Each Comparison Run reports values or indicators for each Outcome Dimension.
+
+**Validation Rules**:
+
+- Must not collapse multiple dimensions into a single best-policy score.
+- Must include caveats where interpretation is context-dependent.
+
+## Entity: Evidence Record
+
+**Purpose**: Captures provenance for assumptions, parameters, and displayed claims.
+
+**Fields**:
+
+- `id`: stable evidence identifier.
+- `evidenceClass`: observed, derived, expert, placeholder, or assumed.
+- `source`: citation or source ID.
+- `method`: method used to derive or apply the evidence.
+- `confidence`: high, medium, or low.
+- `accessDate`: ISO date where available.
+- `selectionBias`: known bias or limitation where available.
+- `notes`: caveats or review notes.
+
+**Relationships**:
+
+- Referenced by Policy Scenarios, Sectors, and Summary Exports.
+
+**Validation Rules**:
+
+- Must distinguish evidence class explicitly.
+- Observed and derived evidence should include source and method.
+- Weak, placeholder, or assumed evidence must be visible to users.
+
+## Entity: Approved Control
+
+**Purpose**: Defines a public user control that can be adjusted for temporary cause-and-effect visualisation.
+
+**Fields**:
+
+- `id`: stable control identifier.
+- `type`: scenario selection, budget envelope, time horizon, or uncertainty range.
+- `label`: user-facing label.
+- `description`: plain-language description.
+- `defaultValue`: value from reviewed content.
+- `allowedRange`: allowed values or range.
+- `appliesTo`: scenario, outcome, sector group, or comparison-wide target.
+- `caveat`: explanatory caveat shown near the control.
+
+**Relationships**:
+
+- Used by Comparison Runs as exploratory input.
+
+**Validation Rules**:
+
+- Must not expose sector-specific parameter editing to public users.
+- Must not alter authoritative data or model parameters.
+- Must be published through reviewed content before appearing in the public app.
+
+## Entity: Comparison Run
+
+**Purpose**: Represents a public browser-session-only comparison state.
+
+**Fields**:
+
+- `selectedScenarioIds`: selected Policy Scenario identifiers.
+- `budgetEnvelope`: exploratory budget envelope.
+- `horizonYears`: exploratory time horizon.
+- `approvedControlValues`: values for approved public controls.
+- `publishedContentVersionId`: content version used.
+- `createdInSessionAt`: client-side timestamp.
+
+**Relationships**:
+
+- References Published Content Version, Policy Scenarios, Approved Controls, Sectors, Outcome Dimensions, and Evidence Records.
+- Can produce one Static Summary Export.
+
+**Validation Rules**:
+
+- Must remain browser-session-only for public users.
+- Must not be saved as an application record.
+- Must flag inconsistent budget, horizon, sector coverage, or scenario assumptions.
+
+## Entity: Static Summary Export
+
+**Purpose**: A downloadable summary for sharing public exploratory results without server-side run persistence.
+
+**Fields**:
+
+- `title`: summary title.
+- `generatedAt`: client-side export timestamp.
+- `publishedContentVersionId`: content version used.
+- `selectedScenarios`: selected scenario names and IDs.
+- `exploratoryInputs`: public input values used.
+- `tradeoffSummary`: outcome dimension summary.
+- `sensitivityNotes`: conclusions sensitive to uncertainty.
+- `evidenceCaveats`: caveats and weak evidence notes.
+- `nonForecastStatement`: required statement that results are comparative and uncertain.
+
+**Relationships**:
+
+- Derived from a Comparison Run.
+
+**Validation Rules**:
+
+- Must include published content version.
+- Must include non-forecast framing.
+- Must include caveats for weak, placeholder, or assumed evidence.
+- Must not imply a definitive recommendation or ranking.
+
+## State Transitions
+
+```text
+Reviewed repo content -> Published Content Version -> Public comparison session -> Static Summary Export
+
+Analyst draft change -> Repository review -> Published Content Version
+Analyst draft change -> Not reviewed -> Not visible as authoritative content
+
+Public exploratory input -> Browser session state -> Discarded when session ends
+Public exploratory input -> Static Summary Export -> Downloaded file only
+```

--- a/specs/001-ai-policy-sandbox-app/plan.md
+++ b/specs/001-ai-policy-sandbox-app/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Interactive AI Policy Sandbox App
+
+**Branch**: `001-build-ai-policy-sandbox` | **Date**: 2026-05-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/001-ai-policy-sandbox-app/spec.md`
+
+## Summary
+
+Build a public showcase application for the New Zealand AI Policy Sandbox. Public users can compare policy scenario archetypes, adjust approved exploratory controls, inspect evidence and sector provenance, and export static summaries. Authoritative data and scenario definitions remain repo-reviewed content consumed by the app, not user-edited app state.
+
+The selected technical approach is a mostly static Next.js application with TypeScript, Tailwind CSS, shadcn/ui, ECharts, Zod validation, and repo-backed YAML/JSON content. Exploratory calculations run client-side for public sessions; public comparison runs are not saved server-side.
+
+## Technical Context
+
+**Language/Version**: TypeScript on current stable Node.js LTS for a Next.js App Router project  
+**Primary Dependencies**: Next.js, React, Tailwind CSS, shadcn/ui, ECharts, Zod, YAML parser, lightweight state/query-string helpers  
+**Storage**: Repo-backed YAML/JSON content under version control; no database for public runs  
+**Testing**: Vitest for schema/model utilities, React Testing Library for components where useful, Playwright for public comparison flows and export behaviour  
+**Target Platform**: Static or mostly static public web app deployable to Vercel free tier for showcase MVP  
+**Project Type**: Web application with client-side exploratory sandbox and repo-reviewed content pipeline  
+**Performance Goals**: First meaningful public view in under 2 seconds on typical broadband; public comparison update in under 250 ms for approved controls; static summary export in under 3 seconds after comparison completion; validate with documented Playwright desktop and mobile profiles using explicit network and CPU throttling assumptions  
+**Constraints**: No public saved runs; no public edits to authoritative data; no forecasts or exact GDP/employment claims; all aggregate comparisons cover all 19 ANZSIC Level 1 sectors; all authoritative inputs trace to reviewed repo content  
+**Scale/Scope**: Showcase MVP for public users, analysts, researchers, and reviewers; initial content covers existing scenario archetypes, sector tiers, core outcome dimensions, evidence classes, and published content versioning
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The ratified constitution is applied as the planning gate:
+
+| Gate | Status | Notes |
+| --- | --- | --- |
+| Policy Sandbox Integrity | PASS | Plan states outputs are comparative reasoning under uncertainty, not forecasts, and requires whole-economy coverage for aggregate comparisons. |
+| Simplicity & Maintainability | PASS | Mostly static Next.js app avoids database, public accounts, server-side saved runs, and a separate backend service for the showcase MVP. |
+| Functional, Type-Safe Implementation | PASS | Zod contracts, TypeScript, and client-side model helpers are planned for structured content, comparison state, and export validation. |
+| UX Uniformity | PASS | Shared app shell, shadcn-compatible components, public controls, caveat copy, and responsive charts are planned. |
+| Evidence Provenance & Reviewed Authority | PASS | Data model and contracts require evidence classes, source metadata, reviewed content versions, and no public authoritative edits. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-ai-policy-sandbox-app/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── data-contracts.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── layout.tsx
+├── page.tsx
+├── compare/
+│   └── page.tsx
+├── evidence/
+│   └── page.tsx
+└── methodology/
+    └── page.tsx
+
+components/
+├── charts/
+├── compare/
+├── evidence/
+├── layout/
+└── ui/
+
+content/
+├── scenarios/
+├── sectors/
+├── evidence/
+├── controls/
+└── versions/
+
+lib/
+├── model/
+├── schemas/
+├── content/
+├── export/
+└── state/
+
+tests/
+├── unit/
+├── contract/
+└── e2e/
+```
+
+**Structure Decision**: Use a single Next.js application at the repository root. Keep public UI in `app/` and `components/`, reusable model and validation logic in `lib/`, and repo-reviewed authoritative content in `content/`. This keeps the showcase deployable as a static or mostly static app while preserving the repo-reviewed content workflow.
+
+## Complexity Tracking
+
+No constitution gate violations are introduced. The plan deliberately avoids a database, authentication surface for public users, server-side saved runs, and separate backend service for the showcase MVP.
+
+## Phase 0 Research Summary
+
+See [research.md](research.md) for decisions. All technical unknowns from the requested stack are resolved.
+
+## Phase 1 Design Summary
+
+See [data-model.md](data-model.md), [contracts/data-contracts.md](contracts/data-contracts.md), and [quickstart.md](quickstart.md). The design models public session-only comparison runs, static summary export, repo-reviewed content versions, sector coverage, evidence provenance, and approved exploratory controls.
+
+## Post-Design Constitution Check
+
+The Phase 1 design continues to pass the constitution gates above:
+
+| Gate | Status | Design Evidence |
+| --- | --- | --- |
+| Policy Sandbox Integrity | PASS | Contracts require caveats, non-forecast summary text, and 19-sector aggregate coverage. |
+| Simplicity & Maintainability | PASS | Session-only public state and static exports avoid extra infrastructure. |
+| Functional, Type-Safe Implementation | PASS | Design defines Zod-backed content, comparison state, and export contracts. |
+| UX Uniformity | PASS | Tasks require shared UI components, consistent public controls, copy review, and responsive chart review. |
+| Evidence Provenance & Reviewed Authority | PASS | Evidence records and content versions are first-class entities consumed from reviewed repository content. |

--- a/specs/001-ai-policy-sandbox-app/quickstart.md
+++ b/specs/001-ai-policy-sandbox-app/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Interactive AI Policy Sandbox App
+
+This quickstart describes how to verify the planned showcase experience once implementation tasks exist. The app is planned as a Next.js + TypeScript public showcase with repo-backed YAML/JSON content and session-only public comparison state.
+
+## Prerequisites
+
+- Node.js current LTS
+- npm or pnpm, to be finalised during implementation setup
+- Reviewed repo-backed content files for scenarios, sectors, evidence, controls, and content version
+
+## Local Setup
+
+```powershell
+npm install
+npm run dev
+```
+
+Open the local URL shown by the dev server.
+
+## Core Verification Flow
+
+1. Open the public sandbox comparison workspace.
+2. Select at least three policy scenarios.
+3. Confirm all core tradeoff dimensions are visible: productivity, adoption spread, labour adjustment pressure, and national enabling capacity.
+4. Adjust only approved public controls: scenario selection, budget envelope, time horizon, and approved uncertainty ranges.
+5. Confirm the app labels adjusted inputs as temporary exploratory visualisation inputs.
+6. Confirm no control allows public editing of sector-specific parameter values, evidence records, source data, model structure, or repository-backed scenario definitions.
+7. Inspect sector coverage and confirm aggregate comparisons include all 19 ANZSIC Level 1 sectors.
+8. Inspect an evidence item and confirm evidence class, source, method, confidence, access date, and selection-bias notes appear where available.
+9. Export a static summary file.
+10. Confirm the export includes selected scenarios, exploratory inputs, published content version, tradeoffs, uncertainty notes, caveats, and non-forecast framing.
+
+## Session-Only Verification
+
+1. Create an exploratory comparison.
+2. Refresh or close the browser session according to the implementation's session boundary.
+3. Confirm the comparison is not available as a saved application record.
+4. Confirm static exports remain local/downloaded files only.
+
+## Content Publication Verification
+
+1. Create a draft change to authoritative data or scenario definitions in repository content.
+2. Confirm the public app continues using the last published reviewed content until a reviewed publication step occurs.
+3. Publish reviewed content.
+4. Confirm the app identifies the new published content version or source revision.
+
+## Build And Test
+
+```powershell
+npm run lint
+npm run test
+npm run test:e2e
+npm run build
+```
+
+The exact package manager and scripts will be finalised during implementation setup.

--- a/specs/001-ai-policy-sandbox-app/research.md
+++ b/specs/001-ai-policy-sandbox-app/research.md
@@ -1,0 +1,55 @@
+# Research: Interactive AI Policy Sandbox App
+
+## Decision: Use Next.js with TypeScript for the public showcase application
+
+**Rationale**: Next.js provides a strong public showcase shell with routing, metadata, static generation, deploy previews, and mature React ecosystem support. TypeScript gives compile-time safety for policy scenario, sector, evidence, and summary-export structures. The app can be hosted on Vercel as a mostly static site and can later move to another static host if needed.
+
+**Alternatives considered**: SvelteKit would be excellent for interactivity but has a smaller contributor pool. Astro with React islands would be strong for an evidence-heavy site, but the core experience is an interactive comparison workspace. Streamlit would be fast for analyst prototyping but less polished and less suitable for public static showcase hosting.
+
+## Decision: Use Tailwind CSS with shadcn/ui for interface composition
+
+**Rationale**: Tailwind and shadcn/ui support a polished, restrained, accessible civic-tech style without introducing a heavy design system. Components remain source-owned and can be adapted to the policy sandbox's dense comparison interface. This suits tabs, filters, evidence panels, controls, and export actions.
+
+**Alternatives considered**: Material UI is comprehensive but visually opinionated and heavier. CSS modules alone would be simple but slower for building a coherent showcase. A fully custom design system would be premature for MVP.
+
+## Decision: Use ECharts for comparison and uncertainty visualisation
+
+**Rationale**: ECharts supports rich interactive charts, responsive dashboards, uncertainty bands, stacked sector views, and comparison visualisations suitable for public exploration. It can render the core tradeoff dimensions clearly while supporting tooltips and annotations that reinforce caveats.
+
+**Alternatives considered**: Observable Plot is elegant for statistical graphics but less dashboard-oriented. Plotly is capable but larger and can feel heavier. Recharts is React-friendly but less flexible for complex uncertainty and sector views.
+
+## Decision: Use Zod for schema validation and runtime data contracts
+
+**Rationale**: Authoritative content is repo-backed YAML/JSON and must be validated before the app treats it as published content. Zod provides TypeScript inference and runtime validation for sector records, scenario records, evidence records, approved controls, content versions, and static summary exports.
+
+**Alternatives considered**: JSON Schema is useful for external validation but less ergonomic in TypeScript. Valibot is lightweight but less familiar. Hand-written validation would risk untraceable data failures.
+
+## Decision: Store authoritative content as repo-backed YAML/JSON
+
+**Rationale**: The specification requires analyst-controlled authoritative data and repository review before publication. YAML/JSON files align with the planned registry direction, allow focused diffs, and support static build-time validation. The application can consume only reviewed content versions and expose the source revision in summaries.
+
+**Alternatives considered**: A database would add operational complexity and conflict with repo-reviewed authority for the MVP. CSV-only storage is familiar but weak for nested provenance and range structures. A headless CMS would introduce another authority path and review workflow.
+
+## Decision: Keep public comparison runs browser-session-only
+
+**Rationale**: The spec states public runs are not saved by the application. Browser-session-only state avoids user accounts, privacy storage, moderation, database costs, and server-side persistence. It supports the Vercel free-tier showcase path.
+
+**Alternatives considered**: Server-saved public runs would require storage, retention policy, moderation, and user identity decisions. Encoded URLs would improve shareability but were not selected. Analyst-only saved runs can be revisited later if needed.
+
+## Decision: Provide static summary export for public sharing
+
+**Rationale**: Static exports meet the sharing requirement without creating saved app records. Exports can include selected scenarios, exploratory inputs, published content version, tradeoffs, uncertainty notes, evidence caveats, and non-forecast framing.
+
+**Alternatives considered**: Server-generated PDFs increase runtime complexity. Saved public links conflict with the session-only requirement. Clipboard-only summaries are too fragile for policy review.
+
+## Decision: Use client-side exploratory calculations for MVP
+
+**Rationale**: Public controls are limited to scenario selection, budget envelope, time horizon, and approved uncertainty ranges. These can be evaluated in the browser using reviewed published content and model utilities. This keeps hosting simple and avoids treating the app as a black-box simulation service.
+
+**Alternatives considered**: Serverless calculation functions may become useful for heavier workloads but add deployment and reproducibility complexity. A separate backend service is not justified for the showcase MVP.
+
+## Decision: Use Vitest and Playwright for validation
+
+**Rationale**: Vitest can validate schemas, comparison helpers, and export generation quickly. Playwright can verify public flows, caveat visibility, session-only behaviour, and chart rendering at desktop and mobile sizes.
+
+**Alternatives considered**: Jest is mature but less aligned with modern Vite-style tooling. Cypress is viable but Playwright is better for multi-browser and export-oriented flows.

--- a/specs/001-ai-policy-sandbox-app/spec.md
+++ b/specs/001-ai-policy-sandbox-app/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Interactive AI Policy Sandbox App
+
+**Feature Branch**: `001-build-ai-policy-sandbox`  
+**Created**: 2026-05-03  
+**Status**: Draft  
+**Input**: User description: "an interactive application as a New Zealand AI Policy Sandbox: a transparent, NZ sector-calibrated policy sandbox for comparing AI policy tradeoffs under uncertainty. Treat it as a policy comparison framework and structured evidence synthesis, not as a forecasting engine, black-box simulator, definitive adoption ranking, or source of exact GDP and employment predictions"
+
+## Clarifications
+
+### Session 2026-05-03
+
+- Q: What access model should the application use for public users versus analysts? → A: Public read-only users can adjust allowed exploratory variables to visualise cause and effect; only analysts can change repository content or authoritative data.
+- Q: Which exploratory variables should public read-only users be allowed to adjust? → A: Public users can adjust scenario selection, budget envelope, time horizon, and approved uncertainty ranges; authoritative data and model parameters remain locked.
+- Q: How should analyst changes become authoritative application data? → A: Analyst changes are made through repository-reviewed data and specification files; the app consumes only published reviewed content.
+- Q: How should public comparison runs be persisted or shared? → A: Public runs exist only in the browser session; users can export a static summary file.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Compare Policy Tradeoffs (Priority: P1)
+
+A public user or policy analyst compares multiple AI policy archetypes under the same high-level assumptions so they can understand tradeoffs across productivity, adoption spread, labour adjustment pressure, and national enabling capacity without treating outputs as forecasts.
+
+**Why this priority**: This is the core purpose of the sandbox and provides the minimum useful experience for structured policy comparison.
+
+**Independent Test**: Can be tested by selecting at least two policy scenarios, applying a common budget and horizon, and reviewing a side-by-side tradeoff summary that explicitly frames results as comparative and uncertain.
+
+**Acceptance Scenarios**:
+
+1. **Given** a public user has opened the sandbox, **When** they select two or more policy scenarios, **Then** the application presents comparable outcomes across all core tradeoff dimensions.
+2. **Given** selected scenarios use different budget or horizon assumptions, **When** the user attempts to compare them, **Then** the application flags the comparability issue and prompts for like-for-like assumptions.
+3. **Given** the user reviews scenario outputs, **When** output values are shown, **Then** the application displays caveats that the outputs are structured comparisons under uncertainty, not forecasts or exact predictions.
+4. **Given** a public user adjusts scenario selection, budget envelope, time horizon, or an approved uncertainty range, **When** the comparison updates, **Then** the application treats the change as a temporary visualisation and does not alter authoritative repository data, evidence records, or model parameters.
+5. **Given** a public user has created an exploratory comparison, **When** they leave the browser session, **Then** the application does not preserve the run as a saved application record.
+
+---
+
+### User Story 2 - Inspect Sector And Evidence Basis (Priority: P2)
+
+A researcher or reviewer inspects how scenario comparisons relate to New Zealand sector coverage and the evidence base, including where evidence is observed, derived, expert, placeholder, or assumed.
+
+**Why this priority**: The sandbox must be transparent enough for reviewers to understand the basis and limits of each comparison.
+
+**Independent Test**: Can be tested by opening a sector or outcome detail view and tracing the displayed assumptions to evidence class, source, method, confidence, access date, and caveat information where available.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reviewer is viewing comparison results, **When** they inspect a sector contribution, **Then** the application identifies the sector, tier, key assumptions, and evidence provenance used in the comparison.
+2. **Given** an assumption relies on weak or placeholder evidence, **When** it appears in the interface, **Then** the application labels the evidence weakness plainly and avoids implying precision.
+3. **Given** whole-economy comparison is requested, **When** the reviewer checks sector coverage, **Then** all 19 ANZSIC Level 1 sectors are represented through the Tier 1, Tier 2, and Tier 3 structure.
+4. **Given** an analyst has proposed a change to authoritative data or scenario definitions, **When** the change has not completed repository review, **Then** the application does not expose it as published authoritative content.
+
+---
+
+### User Story 3 - Explore Uncertainty And Sensitivity (Priority: P3)
+
+A policy user explores how uncertain assumptions affect the direction and relative scale of scenario tradeoffs so they can identify robust conclusions and fragile conclusions.
+
+**Why this priority**: Uncertainty is central to the sandbox framing, but this can build on the core comparison and transparency experience.
+
+**Independent Test**: Can be tested by adjusting assumption ranges and confirming that the application updates the comparison narrative, uncertainty indication, and caveats without producing a single definitive ranking.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is viewing a scenario comparison, **When** they adjust an uncertainty range for an assumption, **Then** the application updates the tradeoff view and indicates which conclusions are sensitive to that assumption.
+2. **Given** scenario results are close or evidence is weak, **When** the user reviews the comparison, **Then** the application identifies the conclusion as uncertain rather than presenting a definitive winner.
+3. **Given** the user wants to share findings, **When** they produce a summary, **Then** the summary includes scenario assumptions, caveats, evidence limitations, and the comparative nature of the result.
+4. **Given** a public user exports a static summary, **When** another person reads it, **Then** the summary includes the selected scenarios, exploratory inputs, published content version, and caveats needed to interpret the result.
+
+### Edge Cases
+
+- When evidence is missing for a sector or parameter, the application must label the gap and use the agreed placeholder or assumed classification rather than hiding the uncertainty.
+- When a user attempts to compare only Tier 1 sectors for an aggregate policy question, the application must warn that whole-economy coverage requires all 19 ANZSIC Level 1 sectors.
+- When a user tries to interpret outputs as exact GDP, employment, adoption, or sector-ranking forecasts, the application must present corrective framing in the result text or summary.
+- When scenarios use different budgets, horizons, or incompatible assumptions, the application must prevent or clearly flag direct head-to-head comparison.
+- When sensitivity changes reverse a tradeoff conclusion, the application must make the reversal visible and identify the assumption behind it.
+- When a public user adjusts scenario selection, budget envelope, time horizon, or approved uncertainty ranges, the application must clearly distinguish those temporary visualisation inputs from analyst-controlled authoritative assumptions, data, and model parameters.
+- When analyst changes are proposed but not yet reviewed through the repository workflow, the application must continue using the last published reviewed content.
+- When a public browser session ends, the application must not retain the user's exploratory comparison as a saved run.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The application MUST provide an interactive policy comparison workspace centred on the New Zealand AI Policy Sandbox framing.
+- **FR-001a**: The application MUST allow public read-only users to explore scenario selection, budget envelope, time horizon, and approved uncertainty ranges for cause-and-effect visualisation without changing repository content, authoritative assumptions, model parameters, or source data.
+- **FR-002**: The application MUST allow users to compare at least two policy scenarios under a shared budget envelope and simulation horizon.
+- **FR-003**: The application MUST support the recognised scenario archetypes, including status quo, aggregate, targeted demand-side, targeted supply-side, and mixed targeted options.
+- **FR-004**: The application MUST represent whole-economy comparisons across all 19 ANZSIC Level 1 sectors using the Tier 1, Tier 2, and Tier 3 structure.
+- **FR-005**: The application MUST report scenario tradeoffs across productivity, adoption spread, labour adjustment pressure, and national enabling capacity.
+- **FR-006**: The application MUST describe outputs as comparative reasoning under uncertainty and MUST NOT present them as forecasts, exact GDP predictions, exact employment predictions, definitive adoption rankings, or definitive sector rankings.
+- **FR-007**: Users MUST be able to inspect sector-level assumptions, outcome drivers, and evidence provenance for displayed comparisons.
+- **FR-008**: Evidence records shown in the application MUST distinguish observed, derived, expert, placeholder, and assumed evidence classes.
+- **FR-009**: Evidence and parameter displays MUST include source, method, confidence, access date, and selection-bias notes where available.
+- **FR-010**: The application MUST make weak, missing, placeholder, or assumed evidence visible in both detailed views and generated summaries.
+- **FR-011**: Users MUST be able to adjust approved uncertainty ranges for comparison purposes while retaining the original evidence and caveat context.
+- **FR-012**: The application MUST identify when conclusions are sensitive to uncertain assumptions.
+- **FR-013**: The application MUST prevent or clearly flag comparisons that use inconsistent budget envelopes, horizons, sector coverage, or scenario assumptions.
+- **FR-014**: Users MUST be able to produce a shareable comparison summary that includes selected scenarios, key assumptions, tradeoffs, uncertainty notes, and evidence caveats.
+- **FR-015**: The application MUST preserve the sandbox's policy-neutral posture by presenting scenarios as archetypes for comparison, not as recommendations.
+- **FR-016**: Only analysts MUST be able to change authoritative data, evidence records, scenario definitions, or repository-backed content.
+- **FR-017**: Public users MUST NOT be able to edit sector-specific parameter values, evidence records, source data, model structure, or repository-backed scenario definitions.
+- **FR-018**: Analyst changes to authoritative data, evidence records, scenario definitions, or specification files MUST become available in the application only after repository review and publication.
+- **FR-019**: The application MUST identify the published content version or source revision used for displayed comparisons.
+- **FR-020**: Public comparison runs MUST remain browser-session-only and MUST NOT be saved as application records.
+- **FR-021**: Public users MUST be able to export a static summary file for an exploratory comparison.
+- **FR-022**: The application MUST use uniform navigation, public controls, terminology, caveat presentation, accessibility patterns, and responsive behaviour across comparison, evidence, methodology, and export flows.
+
+### Key Entities *(include if feature involves data)*
+
+- **Policy Scenario**: A policy archetype or scenario configuration used for comparison, including budget envelope, horizon, assumptions, and caveats.
+- **Sector**: One of the 19 ANZSIC Level 1 sectors, including tier classification and sector-specific assumptions.
+- **Outcome Dimension**: A comparison dimension such as productivity, adoption spread, labour adjustment pressure, or national enabling capacity.
+- **Evidence Record**: A provenance item supporting a parameter, assumption, or sector baseline, including evidence class, source, method, confidence, access date, and limitations.
+- **Published Content Version**: The repository-reviewed data, evidence, scenario, and specification state consumed by the application for authoritative comparisons.
+- **Comparison Run**: A user-created comparison of selected scenarios under shared assumptions, including resulting tradeoffs and uncertainty notes.
+- **Static Summary Export**: A user-generated file containing selected scenarios, exploratory inputs, published content version, tradeoffs, uncertainty notes, and caveats without creating a saved application record.
+- **Sensitivity Setting**: A user-adjustable assumption range used to explore uncertainty and robustness of conclusions.
+- **Exploratory Input**: A public read-only adjustment to scenario selection, budget envelope, time horizon, or an approved uncertainty range, used for temporary cause-and-effect visualisation without changing authoritative data, model parameters, or scenario definitions.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A public user or policy analyst can complete a like-for-like comparison of three scenarios across all core tradeoff dimensions in under 10 minutes.
+- **SC-002**: 100% of aggregate comparison summaries include all 19 ANZSIC Level 1 sectors or explicitly explain why the comparison is not whole-economy.
+- **SC-003**: 100% of generated summaries include language stating that outputs are comparative and uncertain, not forecasts or exact predictions.
+- **SC-004**: At least 90% of test reviewers can trace a displayed sector assumption to its evidence class and source information within two interactions.
+- **SC-005**: At least 90% of test users correctly identify that the sandbox compares policy tradeoffs and does not recommend a single best policy option.
+- **SC-006**: At least 95% of scenario comparisons with inconsistent budget, horizon, or sector coverage are flagged before the user treats them as like-for-like comparisons.
+- **SC-007**: Users can generate a shareable comparison summary containing scenarios, assumptions, tradeoffs, uncertainty notes, and caveats in under 3 minutes after completing a comparison.
+- **SC-008**: 100% of public exploratory input changes are visually labelled as temporary and do not modify authoritative data, evidence records, scenario definitions, or repository-backed content.
+- **SC-009**: 100% of public controls are limited to scenario selection, budget envelope, time horizon, and approved uncertainty ranges unless an analyst has explicitly published a new approved input.
+- **SC-010**: 100% of displayed authoritative comparisons identify the published content version or source revision used.
+- **SC-011**: 100% of public exported summaries include selected scenarios, exploratory inputs, published content version, tradeoffs, uncertainty notes, and caveats.
+- **SC-012**: 0 public exploratory comparison runs are retained as saved application records after the browser session ends.
+
+## Assumptions
+
+- Initial users include public read-only users, policy analysts, researchers, sector reviewers, and collaborators; public users can explore approved variables, while analysts control authoritative data and repository-backed changes through repository review.
+- The current calibrated equation specification is the authoritative basis for model behaviour unless a future planning step explicitly documents a revision.
+- The application uses the repository's existing scenario definitions, evidence classes, and sector tier structure as the starting point.
+- The initial release focuses on comparison, transparency, and evidence synthesis rather than public consultation workflows or operational policy approval.
+- Public sharing in the initial release is handled through static summary export, not server-side saved public runs.
+- Where New Zealand-specific evidence is thin, the application follows the repository's evidence hierarchy: Stats NZ baselines first, then New Zealand policy or industry context, then international benchmarks as caveated derived inputs.

--- a/specs/001-ai-policy-sandbox-app/tasks.md
+++ b/specs/001-ai-policy-sandbox-app/tasks.md
@@ -1,0 +1,228 @@
+# Tasks: Interactive AI Policy Sandbox App
+
+**Input**: Design documents from `specs/001-ai-policy-sandbox-app/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/data-contracts.md](contracts/data-contracts.md), [quickstart.md](quickstart.md)
+
+**Tests**: TDD is not mandated for story work, but constitution-driven validation is included through schema, contract, unit, e2e, type-safety, performance, UX, and copy-review tasks.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the Next.js + TypeScript + Tailwind/shadcn project foundation for the showcase app.
+
+- [ ] T001 Create Next.js package manifest with scripts and dependencies in package.json
+- [ ] T002 Create TypeScript configuration for the app in tsconfig.json
+- [ ] T003 Create Next.js configuration for static-friendly deployment in next.config.ts
+- [ ] T004 [P] Configure Tailwind CSS theme and content paths in tailwind.config.ts
+- [ ] T005 [P] Create global stylesheet with Tailwind layers and base tokens in app/globals.css
+- [ ] T006 [P] Configure linting for TypeScript and React in eslint.config.mjs
+- [ ] T007 [P] Configure Vitest unit test environment in vitest.config.ts
+- [ ] T008 [P] Configure Playwright end-to-end test project in playwright.config.ts
+- [ ] T009 Create root app layout and metadata shell in app/layout.tsx
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish data contracts, repo-backed content loading, shared UI primitives, and model utilities required by all user stories.
+
+**Critical**: No user story work can begin until this phase is complete.
+
+- [ ] T010 Create shared TypeScript domain types in lib/schemas/types.ts
+- [ ] T011 [P] Implement Published Content Version Zod schema in lib/schemas/published-content.ts
+- [ ] T012 [P] Implement Policy Scenario Zod schema in lib/schemas/policy-scenario.ts
+- [ ] T013 [P] Implement Sector Zod schema with 19-sector aggregate coverage validation in lib/schemas/sector.ts
+- [ ] T014 [P] Implement Evidence Record Zod schema in lib/schemas/evidence-record.ts
+- [ ] T015 [P] Implement Approved Control Zod schema in lib/schemas/approved-control.ts
+- [ ] T016 [P] Implement Static Summary Export Zod schema in lib/schemas/static-summary-export.ts
+- [ ] T017 Implement repo-backed content loader and validation pipeline in lib/content/load-content.ts
+- [ ] T018 Create initial reviewed content version record in content/versions/2026-05-03-showcase.json
+- [ ] T019 [P] Create initial scenario archetype content in content/scenarios/showcase-scenarios.yaml
+- [ ] T020 [P] Create initial 19-sector tiered content in content/sectors/anzsic-sectors.yaml
+- [ ] T021 [P] Create initial evidence records for showcase assumptions in content/evidence/showcase-evidence.yaml
+- [ ] T022 [P] Create approved public controls content in content/controls/showcase-controls.yaml
+- [ ] T023 Implement comparison state helpers for browser-session-only state in lib/state/comparison-state.ts
+- [ ] T024 Implement core tradeoff calculation helpers using approved controls in lib/model/compare-scenarios.ts
+- [ ] T025 Implement comparability validation for budget, horizon, sector coverage, and scenario assumptions in lib/model/validate-comparison.ts
+- [ ] T026 Create shared non-forecast caveat text utilities in lib/content/caveats.ts
+- [ ] T027 Create shadcn-compatible base UI components in components/ui/button.tsx
+- [ ] T028 [P] Create shadcn-compatible card component in components/ui/card.tsx
+- [ ] T029 [P] Create shadcn-compatible tabs component in components/ui/tabs.tsx
+- [ ] T030 [P] Create shadcn-compatible slider component in components/ui/slider.tsx
+- [ ] T031 [P] Create responsive app navigation shell in components/layout/app-shell.tsx
+
+**Checkpoint**: Content contracts, validation, shared UI, and model helpers are ready for story implementation.
+
+---
+
+## Phase 3: User Story 1 - Compare Policy Tradeoffs (Priority: P1)
+
+**Goal**: Public users and policy analysts can compare multiple scenario archetypes under like-for-like assumptions and see the core tradeoff dimensions without forecast framing.
+
+**Independent Test**: Select at least two scenarios, apply common budget and horizon values, adjust approved public controls, and confirm the comparison view shows productivity, adoption spread, labour adjustment pressure, and national enabling capacity with caveats.
+
+### Implementation for User Story 1
+
+- [ ] T032 [P] [US1] Create public landing page that routes users into the sandbox in app/page.tsx
+- [ ] T033 [P] [US1] Create scenario selection component in components/compare/scenario-selector.tsx
+- [ ] T034 [P] [US1] Create budget and time horizon controls in components/compare/budget-horizon-controls.tsx
+- [ ] T035 [P] [US1] Create approved uncertainty range controls in components/compare/uncertainty-controls.tsx
+- [ ] T036 [US1] Implement comparison workspace page using session-only state in app/compare/page.tsx
+- [ ] T037 [P] [US1] Create tradeoff summary panel in components/compare/tradeoff-summary.tsx
+- [ ] T038 [P] [US1] Create ECharts tradeoff chart component in components/charts/tradeoff-chart.tsx
+- [ ] T039 [P] [US1] Create comparability warning component in components/compare/comparability-warning.tsx
+- [ ] T040 [US1] Integrate non-forecast framing and caveat text in components/compare/tradeoff-summary.tsx
+- [ ] T041 [US1] Ensure public controls cannot mutate authoritative content in lib/state/comparison-state.ts
+
+**Checkpoint**: User Story 1 is independently functional as the MVP comparison workspace.
+
+---
+
+## Phase 4: User Story 2 - Inspect Sector And Evidence Basis (Priority: P2)
+
+**Goal**: Researchers and reviewers can trace displayed assumptions and sector contributions to evidence class, source, method, confidence, access date, and caveats where available.
+
+**Independent Test**: Open a sector or evidence detail view from a comparison result and trace a displayed assumption to sector tier, evidence class, source information, method, confidence, access date, and caveats.
+
+### Implementation for User Story 2
+
+- [ ] T042 [P] [US2] Create sector coverage panel showing all 19 ANZSIC sectors in components/evidence/sector-coverage-panel.tsx
+- [ ] T043 [P] [US2] Create evidence badge component for observed, derived, expert, placeholder, and assumed classes in components/evidence/evidence-badge.tsx
+- [ ] T044 [P] [US2] Create evidence detail drawer in components/evidence/evidence-detail-drawer.tsx
+- [ ] T045 [US2] Add sector and evidence drill-down interactions to app/compare/page.tsx
+- [ ] T046 [P] [US2] Create evidence index page in app/evidence/page.tsx
+- [ ] T047 [P] [US2] Implement published content version display in components/evidence/content-version-banner.tsx
+- [ ] T048 [US2] Surface weak, placeholder, assumed, and low-confidence evidence caveats in components/evidence/evidence-detail-drawer.tsx
+- [ ] T049 [US2] Enforce last-published reviewed content behaviour in lib/content/load-content.ts
+
+**Checkpoint**: User Story 2 is independently verifiable through sector and evidence inspection.
+
+---
+
+## Phase 5: User Story 3 - Explore Uncertainty And Export Summaries (Priority: P3)
+
+**Goal**: Public users can explore sensitivity to approved uncertainty ranges and export a static summary without creating a saved application record.
+
+**Independent Test**: Adjust an approved uncertainty range, observe sensitivity notes update, export a static summary file, and confirm the app does not retain the public comparison as a saved run after the browser session ends.
+
+### Implementation for User Story 3
+
+- [ ] T050 [P] [US3] Implement sensitivity analysis helper in lib/model/sensitivity.ts
+- [ ] T051 [P] [US3] Create sensitivity notes component in components/compare/sensitivity-notes.tsx
+- [ ] T052 [US3] Connect sensitivity notes to approved uncertainty controls in app/compare/page.tsx
+- [ ] T053 [P] [US3] Implement static summary export generator in lib/export/static-summary.ts
+- [ ] T054 [P] [US3] Create export summary button and status UI in components/compare/export-summary-button.tsx
+- [ ] T055 [US3] Integrate static summary export into comparison workspace in app/compare/page.tsx
+- [ ] T056 [US3] Validate exported summary content with Zod in lib/export/static-summary.ts
+- [ ] T057 [US3] Confirm browser-session-only reset behaviour in lib/state/comparison-state.ts
+
+**Checkpoint**: User Story 3 is independently verifiable through sensitivity exploration and static export.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate end-to-end quality, documentation, accessibility, and deployment readiness across all stories.
+
+- [ ] T058 [P] Create methodology page explaining sandbox framing and limits in app/methodology/page.tsx
+- [ ] T059 [P] Add quickstart usage notes for public showcase users in README.md
+- [ ] T060 [P] Add content authoring guidance for analysts in docs/showcase-content-workflow.md
+- [ ] T061 Create unit coverage for schemas and model utilities in tests/unit/model-and-schema.test.ts
+- [ ] T062 Create contract validation coverage for repo-backed content in tests/contract/content-contracts.test.ts
+- [ ] T063 Create Playwright flow covering comparison, evidence inspection, export, and session-only reset in tests/e2e/public-sandbox.spec.ts
+- [ ] T064 Run quickstart validation commands and record gaps in specs/001-ai-policy-sandbox-app/quickstart.md
+- [ ] T065 Run build validation for the Next.js app using package.json scripts
+- [ ] T066 Audit UI copy for non-forecast framing and NZ English in app/compare/page.tsx
+- [ ] T067 Audit responsive layout and chart readability in components/charts/tradeoff-chart.tsx
+- [ ] T068 Run TypeScript strict type-safety validation for policy-critical paths using package.json scripts
+- [ ] T069 Validate public performance goals for first view, comparison update, and static export in tests/e2e/public-sandbox.spec.ts using Playwright desktop and mobile profiles with documented network and CPU throttling assumptions
+- [ ] T070 Audit UX uniformity for navigation, controls, caveats, and responsive accessibility across app/ and components/
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup completion and blocks all user stories.
+- User Story 1 (Phase 3): depends on Foundational completion and forms the MVP.
+- User Story 2 (Phase 4): depends on Foundational completion; can proceed after User Story 1 shell exists for integration points.
+- User Story 3 (Phase 5): depends on User Story 1 comparison workspace and Foundational export/schema helpers.
+- Polish (Phase 6): depends on selected user stories being complete.
+
+### User Story Dependencies
+
+- US1: no dependency on other user stories after Foundation.
+- US2: can be implemented after Foundation, but `T045` integrates with the comparison page from US1.
+- US3: depends on US1 controls and comparison workspace for sensitivity and export integration.
+
+### Parallel Opportunities
+
+- Setup config tasks `T004` through `T008` can run in parallel.
+- Foundational schema/content tasks `T011` through `T016` and `T019` through `T022` can run in parallel.
+- US1 component tasks `T032` through `T035` and `T037` through `T039` can run in parallel after Foundation.
+- US2 component/page tasks `T042` through `T044`, `T046`, and `T047` can run in parallel after Foundation.
+- US3 helper/component tasks `T050`, `T051`, `T053`, and `T054` can run in parallel after US1 state contracts exist.
+- Polish documentation tasks `T058` through `T060` can run in parallel.
+
+---
+
+## Parallel Examples
+
+### User Story 1
+
+```text
+Task: T033 Create scenario selection component in components/compare/scenario-selector.tsx
+Task: T034 Create budget and time horizon controls in components/compare/budget-horizon-controls.tsx
+Task: T035 Create approved uncertainty range controls in components/compare/uncertainty-controls.tsx
+Task: T038 Create ECharts tradeoff chart component in components/charts/tradeoff-chart.tsx
+```
+
+### User Story 2
+
+```text
+Task: T042 Create sector coverage panel showing all 19 ANZSIC sectors in components/evidence/sector-coverage-panel.tsx
+Task: T043 Create evidence badge component for observed, derived, expert, placeholder, and assumed classes in components/evidence/evidence-badge.tsx
+Task: T044 Create evidence detail drawer in components/evidence/evidence-detail-drawer.tsx
+Task: T046 Create evidence index page in app/evidence/page.tsx
+```
+
+### User Story 3
+
+```text
+Task: T050 Implement sensitivity analysis helper in lib/model/sensitivity.ts
+Task: T051 Create sensitivity notes component in components/compare/sensitivity-notes.tsx
+Task: T053 Implement static summary export generator in lib/export/static-summary.ts
+Task: T054 Create export summary button and status UI in components/compare/export-summary-button.tsx
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 setup.
+2. Complete Phase 2 foundation.
+3. Complete Phase 3 User Story 1.
+4. Validate the comparison workspace independently against its acceptance scenarios.
+5. Demo the public comparison MVP before adding evidence drill-down and export polish.
+
+### Incremental Delivery
+
+1. Deliver Setup and Foundation so content contracts and app shell are stable.
+2. Deliver US1 for public comparison and non-forecast framing.
+3. Deliver US2 for sector and evidence transparency.
+4. Deliver US3 for uncertainty exploration and static summary export.
+5. Complete polish tasks for documentation, accessibility, responsive charts, and validation.
+
+### Validation Focus
+
+- Verify aggregate comparisons include all 19 ANZSIC Level 1 sectors.
+- Verify public controls cannot alter authoritative repo-backed content.
+- Verify weak evidence and placeholder assumptions are visible.
+- Verify static exports include selected scenarios, inputs, published content version, caveats, and non-forecast framing.
+- Verify no public comparison runs are saved as application records.
+- Verify type safety, UX uniformity, and public performance goals before release.


### PR DESCRIPTION
- SCENARIOS.md: three policy archetypes (aggregate, targeted demand-side, targeted supply-side) defined with concrete parameter perturbations against the locked state variables. Baseline and stress intensities, nine-run initial comparison set, outcome measures specified.

- registry/REGISTRY-SCHEMA.md: YAML parameter registry schema with per-cell provenance, range, distribution, history, source references. Directory layout, loader interface, migration plan from current CSV, contributor workflow documented.

Both are v0.1 drafts. Next: review, refine, then implement registry migration and run first v0 simulation against scenario set.

Co-authored-by: Percy <percy@raposo.ai>