### PR TITLE
Adopt Cloudflare Pages with static export (ADR 0001)

### DIFF
--- a/docs/adr/0001-deploy-target.md
+++ b/docs/adr/0001-deploy-target.md
@@ -1,0 +1,205 @@
+# ADR 0001: Deploy target for AIPS showcase
+
+- Status: Accepted
+- Date: 2026-05-16
+- Deciders: AIPS delivery team
+- Technical story: `specs/001-ai-policy-sandbox-app`
+
+## Context
+
+AIPS is being built as a public policy comparison application.
+The current stack is Next.js, TypeScript, Tailwind CSS,
+shadcn/ui, ECharts, and Zod.
+
+The implementation plan originally described a
+"deployable to Vercel free tier" showcase target.
+That wording was suitable as an early default,
+but it did not yet reflect platform selection criteria
+specific to this project and operating context.
+
+This decision records the deployment target for the
+showcase MVP and clarifies how that target aligns with
+functional requirements, risk profile, and ongoing operations.
+
+## Problem statement
+
+The team must choose a deployment target that:
+
+- supports a static-first public web app
+- keeps operations simple for a small delivery team
+- avoids avoidable commercial or usage-policy risk
+- tolerates potentially spiky public traffic
+- aligns with existing hosting and DNS operations
+- preserves a clear path for future server-side additions
+
+## Architecture and delivery constraints
+
+AIPS currently has the following delivery characteristics:
+
+- no authentication surface
+- no database
+- no API routes
+- no Server Actions
+- no ISR requirement
+- no dynamic runtime data fetch requirement
+- all public comparison compute runs client-side
+- content is loaded from repo-reviewed YAML at build time
+- public runs are browser-session-only
+
+Given these constraints, the deployment target does not need
+runtime server capability for MVP.
+
+## Decision
+
+Adopt **Cloudflare Pages** as the deployment target,
+using **Next.js static export** via `output: 'export'`.
+
+Build output for deployment is static HTML, JS, and CSS,
+served from the `out/` directory produced by `npm run build`.
+
+This decision is based on the factors below.
+
+### 1) App is genuinely static
+
+AIPS does not rely on runtime server features in scope.
+Comparison logic, sensitivity behaviour, and summary export
+run in the browser session.
+
+Authoritative content is repo-reviewed and consumed at build time.
+This fits static export directly.
+
+### 2) Operational consistency
+
+Other production sites for this owner run on Cloudflare Pages
+or adjacent Cloudflare services.
+
+Selecting Cloudflare Pages keeps deployment, access,
+and operational conventions in one platform instead of
+splitting one project onto a separate provider.
+
+### 3) Commercial-use policy risk reduction
+
+Cloudflare Pages free tier has no equivalent commercial-use
+restriction that maps to the Vercel Hobby clause.
+
+AIPS is launching under AI for Good NZ and is currently
+non-commercial, but policy should not create a future constraint
+if that boundary changes.
+
+### 4) Bandwidth risk reduction
+
+Cloudflare Pages free tier includes unmetered bandwidth.
+Vercel Hobby has a monthly bandwidth cap.
+
+For a public policy tool that may receive sudden traffic
+from media or government-linked sharing, unmetered bandwidth
+removes a known operational risk class.
+
+### 5) Security posture on free tier
+
+Cloudflare provides DDoS protection, WAF capability,
+and bot-management controls as first-class platform features.
+
+For a public-facing policy tool, this baseline is useful
+without introducing extra paid security layers at launch.
+
+### 6) DNS alignment assumption
+
+`aiforgood.org.nz` DNS is assumed to be managed on Cloudflare.
+If confirmed, custom domain onboarding and TLS setup are
+simpler within one provider boundary.
+
+This is an assumption to verify before launch.
+
+### 7) Future extension path
+
+If later scope introduces telemetry or lightweight server endpoints
+for features such as "email me this summary", Cloudflare Workers
+provides a co-located path in the same dashboard and account model.
+
+## Consequences
+
+### Positive consequences
+
+- Deployment target matches static app architecture.
+- No dependency on Next.js runtime adapters for MVP.
+- Lower operational surface area for team administration.
+- Lower risk of free-tier bandwidth exhaustion.
+- Lower policy risk from commercial-use restrictions.
+- Baseline edge security controls are available by default.
+- Clear progression path if small server workloads are added later.
+
+### Negative consequences
+
+- No runtime `next/image` optimisation.
+  Image optimisation must be handled at build time or in assets.
+- No ISR, Server Actions, or dynamic runtime RSC fetch capability
+  under the current static-export mode.
+- Any future move to runtime server features will require a new
+  architecture decision and likely platform adapter work.
+
+### Tradeoffs accepted
+
+- Using static export intentionally constrains runtime feature use.
+  This is acceptable because current requirements do not need those
+  capabilities.
+- Chart-heavy UI relies mainly on ECharts canvas rendering,
+  so runtime image optimisation limits are minor for MVP.
+- Content updates require rebuild and redeploy.
+  This matches the intended authoritative-content workflow.
+
+## Alternatives considered
+
+## Alternative A: Vercel Hobby with mostly static Next.js
+
+### Pros
+
+- First-party alignment with Next.js defaults.
+- Strong preview deployment workflow by default.
+- Minimal setup for common Next.js usage patterns.
+
+### Cons
+
+- Hobby tier has a monthly bandwidth cap.
+- Hobby terms include commercial-use limits that may create future
+  governance risk even if current launch is non-commercial.
+- Adds another provider dashboard, billing context,
+  and access-management surface for a single app.
+- Operational posture diverges from existing site fleet.
+
+### Why not selected
+
+Vercel is technically viable.
+It was not selected because Cloudflare Pages offers a better fit
+for this static workload and existing operational context,
+with fewer future policy and bandwidth risks.
+
+## Implementation notes
+
+- In `next.config.ts`, set `output: 'export'`.
+- Ensure `npm run build` produces the `out/` directory for Pages.
+- Configure Cloudflare Pages project build settings accordingly.
+- Keep content loading build-time only for MVP scope.
+
+These points imply a small update to Setup tasks
+(T001 to T009 in the planning artefacts),
+particularly T003 and build-output expectations.
+
+## Open questions and assumptions to verify before launch
+
+1. Confirm DNS provider for `aiforgood.org.nz` is Cloudflare.
+2. Confirm custom-domain choice for AIPS
+   (for example `aips.aiforgood.org.nz` or another subdomain).
+3. Confirm preview-deployment workflow requirements:
+   - branch preview URL retention policy
+   - access expectations for internal reviewers
+   - promotion path from preview to production
+4. Confirm whether Cloudflare Pages project-level WAF rules
+   need explicit hardening before public launch.
+
+## References
+
+- `specs/001-ai-policy-sandbox-app/spec.md`
+- `specs/001-ai-policy-sandbox-app/plan.md`
+- `specs/001-ai-policy-sandbox-app/research.md`
+- `specs/001-ai-policy-sandbox-app/tasks.md`

--- a/specs/001-ai-policy-sandbox-app/plan.md
+++ b/specs/001-ai-policy-sandbox-app/plan.md
@@ -15,7 +15,7 @@ The selected technical approach is a mostly static Next.js application with Type
 **Primary Dependencies**: Next.js, React, Tailwind CSS, shadcn/ui, ECharts, Zod, YAML parser, lightweight state/query-string helpers  
 **Storage**: Repo-backed YAML/JSON content under version control; no database for public runs  
 **Testing**: Vitest for schema/model utilities, React Testing Library for components where useful, Playwright for public comparison flows and export behaviour  
-**Target Platform**: Static or mostly static public web app deployable to Vercel free tier for showcase MVP  
+**Target Platform**: Static public web app deployable to Cloudflare Pages using Next.js static export (`output: 'export'`) for showcase MVP  
 **Project Type**: Web application with client-side exploratory sandbox and repo-reviewed content pipeline  
 **Performance Goals**: First meaningful public view in under 2 seconds on typical broadband; public comparison update in under 250 ms for approved controls; static summary export in under 3 seconds after comparison completion; validate with documented Playwright desktop and mobile profiles using explicit network and CPU throttling assumptions  
 **Constraints**: No public saved runs; no public edits to authoritative data; no forecasts or exact GDP/employment claims; all aggregate comparisons cover all 19 ANZSIC Level 1 sectors; all authoritative inputs trace to reviewed repo content  
@@ -100,6 +100,15 @@ No constitution gate violations are introduced. The plan deliberately avoids a d
 ## Phase 0 Research Summary
 
 See [research.md](research.md) for decisions. All technical unknowns from the requested stack are resolved.
+
+Deployment target decision is captured in [ADR 0001](../../docs/adr/0001-deploy-target.md).
+
+## Setup Phase Follow-up Note
+
+Setup tasks T001 to T009 require a small deployment alignment update during implementation:
+
+- T003 should set `output: 'export'` in `next.config.ts`.
+- Build configuration should use `npm run build` producing the `out/` directory for Cloudflare Pages.
 
 ## Phase 1 Design Summary
 

--- a/specs/001-ai-policy-sandbox-app/research.md
+++ b/specs/001-ai-policy-sandbox-app/research.md
@@ -1,8 +1,10 @@
 # Research: Interactive AI Policy Sandbox App
 
+Deployment platform selection is recorded in [ADR 0001](../../docs/adr/0001-deploy-target.md).
+
 ## Decision: Use Next.js with TypeScript for the public showcase application
 
-**Rationale**: Next.js provides a strong public showcase shell with routing, metadata, static generation, deploy previews, and mature React ecosystem support. TypeScript gives compile-time safety for policy scenario, sector, evidence, and summary-export structures. The app can be hosted on Vercel as a mostly static site and can later move to another static host if needed.
+**Rationale**: Next.js provides a strong public showcase shell with routing, metadata, static generation, deploy previews, and mature React ecosystem support. TypeScript gives compile-time safety for policy scenario, sector, evidence, and summary-export structures. The app is targeted for Cloudflare Pages using static export (`output: 'export'`), which matches current requirements with no runtime server features.
 
 **Alternatives considered**: SvelteKit would be excellent for interactivity but has a smaller contributor pool. Astro with React islands would be strong for an evidence-heavy site, but the core experience is an interactive comparison workspace. Streamlit would be fast for analyst prototyping but less polished and less suitable for public static showcase hosting.
 
@@ -32,7 +34,7 @@
 
 ## Decision: Keep public comparison runs browser-session-only
 
-**Rationale**: The spec states public runs are not saved by the application. Browser-session-only state avoids user accounts, privacy storage, moderation, database costs, and server-side persistence. It supports the Vercel free-tier showcase path.
+**Rationale**: The spec states public runs are not saved by the application. Browser-session-only state avoids user accounts, privacy storage, moderation, database costs, and server-side persistence. It aligns with a static-export deployment to Cloudflare Pages and keeps operational complexity low.
 
 **Alternatives considered**: Server-saved public runs would require storage, retention policy, moderation, and user identity decisions. Encoded URLs would improve shareability but were not selected. Analyst-only saved runs can be revisited later if needed.
 


### PR DESCRIPTION
## Summary
- add ADR 0001 documenting the deploy target decision for AIPS
- switch plan and research docs from Vercel showcase wording to Cloudflare Pages with Next.js static export (output: export)
- add follow-up note that Setup tasks T001-T009 need deployment alignment, including next.config.ts output and out/ build output expectations

## Scope
- docs only
- no implementation tasks started
- no changes to tasks.md or spec.md