### PR TITLE
Standardise chart headers with ChartIntro and plain-English deep-links

### DIFF
--- a/app/baseline/page.tsx
+++ b/app/baseline/page.tsx
@@ -120,25 +120,31 @@ export default function BaselinePage() {
           </p>
         </div>
         <div className="surface-card p-5">
-          <p className="eyebrow">Highest sector</p>
+          <p className="eyebrow">Highest current adoption</p>
           <p className="mt-2 font-display text-2xl text-ink">
             {snap.spread.max.name}
           </p>
-          <p className="mt-1 text-sm text-steel">A₀ ≈ {maxPct}%</p>
+          <p className="mt-1 text-sm text-steel">About {maxPct}% of activity today</p>
           <p className="mt-2 text-xs leading-relaxed text-steel">
             Tier {snap.spread.max.tier} · evidence: {snap.spread.max.evidenceClass} ·
             confidence: {snap.spread.max.confidence}
           </p>
+          <p className="mt-2 text-[11px] text-steel">
+            Technical name: <code className="font-mono text-ink">A_s at t=0 ≈ {maxPct}%</code>
+          </p>
         </div>
         <div className="surface-card p-5">
-          <p className="eyebrow">Lowest sector</p>
+          <p className="eyebrow">Lowest current adoption</p>
           <p className="mt-2 font-display text-2xl text-ink">
             {snap.spread.min.name}
           </p>
-          <p className="mt-1 text-sm text-steel">A₀ ≈ {minPct}%</p>
+          <p className="mt-1 text-sm text-steel">About {minPct}% of activity today</p>
           <p className="mt-2 text-xs leading-relaxed text-steel">
             Tier {snap.spread.min.tier} · evidence: {snap.spread.min.evidenceClass} ·
             confidence: {snap.spread.min.confidence}
+          </p>
+          <p className="mt-2 text-[11px] text-steel">
+            Technical name: <code className="font-mono text-ink">A_s at t=0 ≈ {minPct}%</code>
           </p>
         </div>
       </section>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -96,15 +96,19 @@ export default function ComparePage() {
               scenarios={comparison.scenarios}
               series="pBar"
               title="Whole-economy productivity over time"
-              subtitle="GDP-weighted P-bar(t) across all 19 sectors. Dashed line is the status-quo reference."
+              subtitle="Productivity averaged across all 19 sectors using each sector's share of GDP. The dashed line is the status-quo reference - carrying today's values forward unchanged."
               yLabel="P-bar (0 to 1)"
+              symbol="P-bar(t), GDP-weighted"
+              explainerHref="/how-it-works#equations"
             />
             <TrajectoryChart
               scenarios={comparison.scenarios}
               series="E"
               title="National enabling capacity over time"
-              subtitle="Shared enabling stock E(t). The supply-side scenario lifts E directly; demand-side does not."
+              subtitle="The shared conditions every sector draws on - skills, infrastructure, trust, regulation. Supply-side scenarios lift this directly; demand-side scenarios do not."
               yLabel="E (0 to 1)"
+              symbol="E(t)"
+              explainerHref="/how-it-works#equations"
             />
           </section>
 

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -214,7 +214,7 @@ export default function HowItWorksPage() {
         </article>
       </section>
 
-      <section className="mt-8 surface-card p-6">
+      <section id="why" className="mt-8 surface-card p-6 scroll-mt-24">
         <p className="eyebrow">Why we built it</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
           AI policy is being shaped without a shared picture
@@ -229,7 +229,7 @@ export default function HowItWorksPage() {
         </div>
       </section>
 
-      <section className="mt-8 surface-card p-6">
+      <section id="big-idea" className="mt-8 surface-card p-6 scroll-mt-24">
         <p className="eyebrow">The big idea</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
           A test kitchen, not a weather forecast
@@ -247,7 +247,7 @@ export default function HowItWorksPage() {
         </p>
       </section>
 
-      <section className="mt-8">
+      <section id="five-things" className="mt-8 scroll-mt-24">
         <header className="mb-3">
           <p className="eyebrow">The five things we track</p>
           <h2 className="mt-1 font-display text-2xl text-ink">
@@ -272,7 +272,7 @@ export default function HowItWorksPage() {
         </div>
       </section>
 
-      <section className="mt-8 surface-card p-6">
+      <section id="bathtub" className="mt-8 surface-card p-6 scroll-mt-24">
         <p className="eyebrow">How every equation works (one picture)</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
           Think of each quantity as a bathtub
@@ -293,7 +293,7 @@ export default function HowItWorksPage() {
         </div>
       </section>
 
-      <section className="mt-8">
+      <section id="equations" className="mt-8 scroll-mt-24">
         <header className="mb-3">
           <p className="eyebrow">The equations, in plain English</p>
           <h2 className="mt-1 font-display text-2xl text-ink">
@@ -327,7 +327,7 @@ export default function HowItWorksPage() {
         </p>
       </section>
 
-      <section className="mt-8 surface-card p-6">
+      <section id="tiers" className="mt-8 surface-card p-6 scroll-mt-24">
         <p className="eyebrow">Why three tiers</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
           A road atlas of the economy
@@ -351,7 +351,7 @@ export default function HowItWorksPage() {
         </div>
       </section>
 
-      <section className="mt-8">
+      <section id="scenarios" className="mt-8 scroll-mt-24">
         <header className="mb-3">
           <p className="eyebrow">The five policy scenarios</p>
           <h2 className="mt-1 font-display text-2xl text-ink">
@@ -375,7 +375,7 @@ export default function HowItWorksPage() {
         </div>
       </section>
 
-      <section className="mt-8 rounded-2xl border border-datum/25 bg-datum/10 p-6">
+      <section id="limits" className="mt-8 scroll-mt-24 rounded-2xl border border-datum/25 bg-datum/10 p-6">
         <p className="eyebrow">What this cannot tell you</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
           Honest limits, kept in view

--- a/components/baseline/baseline-sector-chart.tsx
+++ b/components/baseline/baseline-sector-chart.tsx
@@ -1,3 +1,4 @@
+import ChartIntro from "@/components/charts/chart-intro";
 import type { BaselineSectorPoint } from "@/lib/model/baseline";
 
 type Props = {
@@ -32,19 +33,13 @@ export default function BaselineSectorChart({ sectors }: Props) {
 
   return (
     <figure className="surface-card p-5">
-      <figcaption className="mb-3">
-        <p className="eyebrow">Sector adoption today</p>
-        <h3 className="mt-1 font-display text-xl text-ink">
-          Where each sector stands now (A_s at t=0)
-        </h3>
-        <p className="mt-1 max-w-3xl text-sm text-steel">
-          One bar per ANZSIC Level 1 sector, ordered from highest to lowest
-          current AI use. The wide spread is the fragmentation finding from the
-          evidence base — different surveys point to between 32% and 87% national
-          adoption depending on what is counted. Treat each value as a calibrated
-          estimate, not an exact measurement.
-        </p>
-      </figcaption>
+      <ChartIntro
+        eyebrow="Sector adoption today"
+        title="Where each sector stands today"
+        description="One bar per ANZSIC Level 1 sector, ordered from highest to lowest current AI use. The wide spread is the fragmentation finding from the evidence base — different surveys point to between 32% and 87% national adoption depending on what is counted. Treat each value as a calibrated estimate, not an exact measurement."
+        symbol="A_s at t = 0"
+        explainerHref="/how-it-works#five-things"
+      />
 
       <svg
         viewBox={`0 0 ${WIDTH} ${height}`}

--- a/components/baseline/national-capacity-dial.tsx
+++ b/components/baseline/national-capacity-dial.tsx
@@ -1,3 +1,5 @@
+import ChartIntro from "@/components/charts/chart-intro";
+
 type Props = {
   value: number; // 0..1
   label: string;
@@ -18,11 +20,13 @@ export default function NationalCapacityDial({ value, label, caption }: Props) {
 
   return (
     <figure className="surface-card p-5">
-      <figcaption className="mb-3">
-        <p className="eyebrow">National enabling capacity</p>
-        <h3 className="mt-1 font-display text-xl text-ink">{label}</h3>
-        <p className="mt-1 text-sm text-steel">{caption}</p>
-      </figcaption>
+      <ChartIntro
+        eyebrow="National enabling capacity"
+        title="National enabling capacity, today"
+        description={caption}
+        symbol={label}
+        explainerHref="/how-it-works#five-things"
+      />
 
       <svg
         viewBox={`0 0 ${W} ${H}`}

--- a/components/charts/chart-intro.tsx
+++ b/components/charts/chart-intro.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+type Props = {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  symbol?: string;
+  explainerHref?: string;
+  explainerLabel?: string;
+};
+
+export default function ChartIntro({
+  eyebrow,
+  title,
+  description,
+  symbol,
+  explainerHref,
+  explainerLabel = "What this means",
+}: Props) {
+  const hasFooter = Boolean(symbol || explainerHref);
+  return (
+    <header className="mb-3">
+      {eyebrow ? <p className="eyebrow">{eyebrow}</p> : null}
+      <h3 className="mt-1 font-display text-xl text-ink break-words">{title}</h3>
+      {description ? (
+        <p className="mt-1 max-w-3xl text-sm text-steel">{description}</p>
+      ) : null}
+      {hasFooter ? (
+        <div className="mt-2 flex flex-col gap-1 text-xs text-steel sm:flex-row sm:items-baseline sm:justify-between sm:gap-3">
+          {symbol ? (
+            <span>
+              Technical name:{" "}
+              <code className="font-mono text-[11px] text-ink">{symbol}</code>
+            </span>
+          ) : (
+            <span aria-hidden />
+          )}
+          {explainerHref ? (
+            <Link
+              href={explainerHref}
+              className="font-medium text-ink underline underline-offset-4"
+            >
+              {explainerLabel} -&gt;
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/components/compare/sector-adoption-chart.tsx
+++ b/components/compare/sector-adoption-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ChartIntro from "@/components/charts/chart-intro";
 import type { ScenarioOutcomes } from "@/lib/model/compare";
 
 type Props = {
@@ -31,15 +32,13 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
 
   return (
     <figure className="surface-card p-5">
-      <figcaption className="mb-3">
-        <h3 className="font-display text-xl text-ink">
-          Sector adoption at year {horizonYears}
-        </h3>
-        <p className="text-sm text-steel">
-          A_s at the horizon for each of the 19 sectors. Reference scenario
-          shown alongside selected runs. Tier colour band on the left.
-        </p>
-      </figcaption>
+      <ChartIntro
+        eyebrow="Sector adoption at the end of the run"
+        title={`Where each sector lands after ${horizonYears} year${horizonYears === 1 ? "" : "s"}`}
+        description="One row per ANZSIC Level 1 sector. The status-quo run is shown alongside the scenarios you selected so you can see how each option pulls each sector. Colour band on the left marks the tier."
+        symbol="A_s at t = horizon"
+        explainerHref="/how-it-works#five-things"
+      />
 
       <svg
         viewBox={`0 0 ${WIDTH} ${height}`}

--- a/components/compare/trajectory-chart.tsx
+++ b/components/compare/trajectory-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ChartIntro from "@/components/charts/chart-intro";
 import type { ScenarioOutcomes, SeriesPoint } from "@/lib/model/compare";
 
 type SeriesSelector = "pBar" | "E";
@@ -10,6 +11,8 @@ type Props = {
   title: string;
   subtitle: string;
   yLabel: string;
+  symbol?: string;
+  explainerHref?: string;
 };
 
 const PALETTE = [
@@ -34,6 +37,8 @@ export default function TrajectoryChart({
   title,
   subtitle,
   yLabel,
+  symbol,
+  explainerHref,
 }: Props) {
   if (scenarios.length === 0) return null;
 
@@ -62,10 +67,12 @@ export default function TrajectoryChart({
 
   return (
     <figure className="surface-card p-5">
-      <figcaption className="mb-3">
-        <h3 className="font-display text-xl text-ink">{title}</h3>
-        <p className="text-sm text-steel">{subtitle}</p>
-      </figcaption>
+      <ChartIntro
+        title={title}
+        description={subtitle}
+        symbol={symbol}
+        explainerHref={explainerHref}
+      />
 
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}


### PR DESCRIPTION
## Summary

Fixes the "(A_s at t=0)" label that read as cut-off / broken on the `/baseline` sector chart, and standardises every chart header in the app on a single plain-English pattern with a deep-link into the new `/how-it-works` explainer.

## Pattern

New `components/charts/chart-intro.tsx` renders, in order:
1. `eyebrow` (optional)
2. Plain-English `h3` title with `break-words`
3. Plain-English description
4. Footer row: muted `Technical name: <symbol>` on the left, `What this means ->` link on the right (stacks below 640 px)

## Applied to

| Chart | Old title | New title | Symbol | Link target |
|---|---|---|---|---|
| `BaselineSectorChart` | "Where each sector stands now (A_s at t=0)" | "Where each sector stands today" | `A_s at t = 0` | `#five-things` |
| `NationalCapacityDial` | `E0 = 0.62` (as h3) | "National enabling capacity, today" | `E_0 = 0.62` | `#five-things` |
| `SectorAdoptionChart` | "Sector adoption at year 10" + "A_s at the horizon..." | "Where each sector lands after 10 years" | `A_s at t = horizon` | `#five-things` |
| `TrajectoryChart` (productivity) | "Whole-economy productivity over time" + "GDP-weighted P-bar(t)..." | same title, plain subtitle | `P-bar(t), GDP-weighted` | `#equations` |
| `TrajectoryChart` (capacity) | "National enabling capacity over time" + "Shared enabling stock E(t)..." | same title, plain subtitle | `E(t)` | `#equations` |

## Other changes

- `app/how-it-works/page.tsx`: added `id` attributes (`why`, `big-idea`, `five-things`, `bathtub`, `equations`, `tiers`, `scenarios`, `limits`) plus `scroll-mt-24` so deep-links land below the sticky header. No copy changes.
- `app/baseline/page.tsx`: "Highest/Lowest sector" stat cards reworked to lead with plain English ("Highest current adoption", "About 36% of activity today") and demote `A₀` to a muted technical tail.
- `TrajectoryChart` API gains two optional props (`symbol`, `explainerHref`); existing call sites updated.

## Decisions captured in the plan

- Single shared `ChartIntro` rather than per-chart edits.
- Symbols kept visible but demoted - technical readers still see them.
- Anchor IDs on `<section>` elements, not cards, so they survive copy edits.
- Default link label: `What this means ->`.
- `NationalCapacityDial`: keep `E₀ = …` label inside the dial SVG **and** add `ChartIntro` above (less disruptive than stripping the in-dial label).

## Out of scope

- Rewriting `dimensionLabel` strings inside `ScenarioResultsCard` (already human-friendly).
- Tooltips/popovers; axis-tick rewording; KaTeX-style symbol rendering.

## Validation

- `npm run lint` clean
- `npm run typecheck` clean
- `npm run build` green - 9 static routes unchanged
- 360 px responsive check: titles wrap inside the card; footer row stacks; no horizontal overflow.