### PR TITLE
Silence inline-style advisories on chart legend swatches

### DIFF
--- a/components/compare/sector-adoption-chart.tsx
+++ b/components/compare/sector-adoption-chart.tsx
@@ -127,15 +127,21 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
 
       <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-steel">
         <li className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: TIER_COLOUR[1] }} />
+          <svg aria-hidden width={8} height={8} className="inline-block">
+            <rect width={8} height={8} rx={1.5} fill={TIER_COLOUR[1]} />
+          </svg>
           Tier 1 (full state)
         </li>
         <li className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: TIER_COLOUR[2] }} />
+          <svg aria-hidden width={8} height={8} className="inline-block">
+            <rect width={8} height={8} rx={1.5} fill={TIER_COLOUR[2]} />
+          </svg>
           Tier 2 (reduced)
         </li>
         <li className="flex items-center gap-1.5">
-          <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: TIER_COLOUR[3] }} />
+          <svg aria-hidden width={8} height={8} className="inline-block">
+            <rect width={8} height={8} rx={1.5} fill={TIER_COLOUR[3]} />
+          </svg>
           Tier 3 (adoption only)
         </li>
       </ul>

--- a/components/compare/trajectory-chart.tsx
+++ b/components/compare/trajectory-chart.tsx
@@ -177,23 +177,28 @@ export default function TrajectoryChart({
       </svg>
 
       <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-steel">
-        {scenarios.map((s, i) => (
-          <li key={s.scenarioId} className="flex items-center gap-2">
-            <span
-              aria-hidden
-              className="inline-block h-0.5 w-5"
-              style={{
-                backgroundColor: PALETTE[i % PALETTE.length],
-                borderTop: s.isReference ? `2px dashed ${PALETTE[i % PALETTE.length]}` : undefined,
-                height: 0,
-              }}
-            />
-            <span>
-              {s.scenarioName}
-              {s.isReference ? " (reference)" : ""}
-            </span>
-          </li>
-        ))}
+        {scenarios.map((s, i) => {
+          const colour = PALETTE[i % PALETTE.length];
+          return (
+            <li key={s.scenarioId} className="flex items-center gap-2">
+              <svg aria-hidden width={20} height={6} className="inline-block">
+                <line
+                  x1={0}
+                  x2={20}
+                  y1={3}
+                  y2={3}
+                  stroke={colour}
+                  strokeWidth={2}
+                  strokeDasharray={s.isReference ? "4 3" : undefined}
+                />
+              </svg>
+              <span>
+                {s.scenarioName}
+                {s.isReference ? " (reference)" : ""}
+              </span>
+            </li>
+          );
+        })}
       </ul>
     </figure>
   );


### PR DESCRIPTION
## Summary

VS Code's Problems panel was reporting "CSS inline styles should not be used" advisories on the tier swatches in `SectorAdoptionChart` and the scenario swatches in `TrajectoryChart`. Production `next build` and `npm run lint` were both clean - these were editor-side advisories only - but they cluttered the panel and read as "build errors".

## Cause

Both legends rendered colour swatches as `<span style={{ backgroundColor: ... }} />`. Because the colours come from a runtime `TIER_COLOUR` map (1-3) and a per-index `PALETTE`, Tailwind classes cannot express them.

## Fix

Render the swatches as inline SVG `<rect>` / `<line>` elements instead. SVG `fill` and `stroke` are attributes, not CSS inline styles, so the advisor stops flagging them and the legends look identical.

## Validation

- `npm run lint` clean
- `npm run build` clean - 9 static routes unchanged
- Editor Problems panel: 0 entries on the two affected files