### PR TITLE
fix(charts): collapse SVG &lt;title&gt; children to single string to avoid hydration mismatch

### DIFF
--- a/components/baseline/baseline-sector-chart.tsx
+++ b/components/baseline/baseline-sector-chart.tsx
@@ -97,10 +97,7 @@ export default function BaselineSectorChart({ sectors }: Props) {
                   fill={TIER_COLOUR[s.tier]}
                   opacity={0.85}
                 >
-                  <title>
-                    {s.name}: A₀ = {s.A0.toFixed(2)} · evidence: {s.evidenceClass} · confidence: {s.confidence}
-                    {s.notes ? ` · ${s.notes}` : ""}
-                  </title>
+                  <title>{`${s.name}: A₀ = ${s.A0.toFixed(2)} · evidence: ${s.evidenceClass} · confidence: ${s.confidence}${s.notes ? ` · ${s.notes}` : ""}`}</title>
                 </rect>
                 <text
                   x={xScale(s.A0) + 4}

--- a/components/compare/sector-adoption-chart.tsx
+++ b/components/compare/sector-adoption-chart.tsx
@@ -110,9 +110,7 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
                       fill={colour}
                       opacity={s.isReference ? 0.5 : 0.9}
                     >
-                      <title>
-                        {s.scenarioName}: A = {value.toFixed(3)}
-                      </title>
+                      <title>{`${s.scenarioName}: A = ${value.toFixed(3)}`}</title>
                     </rect>
                   );
                 })}


### PR DESCRIPTION
## What

Fixes the React 19 hydration mismatch reported on `/compare` (and latent on `/baseline`):

```
Hydration failed because the server rendered HTML didn't match the client.
...
> 113 |                       <title>
                              ^
  114 |                         {s.scenarioName}: A = {value.toFixed(3)}
  115 |                       </title>
```

## Why

JSX like

```tsx
<title>
  {s.scenarioName}: A = {value.toFixed(3)}
</title>
```

compiles to multiple text children for the SVG `<title>` element, including leading/trailing whitespace text nodes. Next 16's server renderer and the browser parser disagree on how to serialise that whitespace inside SVG `<title>`, so hydration fails on every Compare run.

## Fix

Collapse the title content to a single template literal child, removing all whitespace ambiguity:

```tsx
<title>{`${s.scenarioName}: A = ${value.toFixed(3)}`}</title>
```

Applied in two places: `components/compare/sector-adoption-chart.tsx` and `components/baseline/baseline-sector-chart.tsx` (which had the same pattern and would have tripped the same warning on `/baseline`).

## Verification

- `npm run build` clean; all 9 static routes generated.
- No other `<title>` elements in the components tree use the multi-child pattern.