### PR TITLE
feat(evidence): APAC OECD AI investment comparison table

### DIFF
--- a/app/evidence/page.tsx
+++ b/app/evidence/page.tsx
@@ -1,3 +1,4 @@
+import ApacInvestmentTable from "@/components/evidence/apac-investment-table";
 import PageHeader from "@/components/layout/page-header";
 import { EVIDENCE_CLASSES } from "@/lib/reference-data";
 
@@ -23,6 +24,10 @@ export default function EvidencePage() {
           ))}
         </ul>
       </section>
+
+      <div className="mt-6">
+        <ApacInvestmentTable />
+      </div>
 
       <section className="mt-6 rounded-2xl border border-accent/30 bg-accent/10 p-6">
         <h2 className="font-display text-2xl text-ink">Implementation status</h2>

--- a/components/evidence/apac-investment-table.tsx
+++ b/components/evidence/apac-investment-table.tsx
@@ -1,0 +1,228 @@
+import {
+  OECD_APAC_META,
+  OECD_APAC_ROWS,
+  type OECDApacRow,
+} from "@/lib/oecd-apac";
+
+function formatUsd(approxUsdMillions: number | null): string {
+  if (approxUsdMillions === null) return "n/a";
+  if (approxUsdMillions >= 1000) {
+    return `\u2248 US$${(approxUsdMillions / 1000).toFixed(1)}B`;
+  }
+  return `\u2248 US$${approxUsdMillions.toLocaleString()}M`;
+}
+
+function formatPerCapita(row: OECDApacRow): string {
+  if (row.investment.approxUsdMillions === null) return "n/a";
+  // Per-capita USD = (USD millions * 1,000,000) / (population millions * 1,000,000)
+  const perCapita = row.investment.approxUsdMillions / row.populationMillions;
+  if (perCapita >= 100) return `\u2248 US$${perCapita.toFixed(0)}/person`;
+  return `\u2248 US$${perCapita.toFixed(1)}/person`;
+}
+
+function confidenceTone(c: OECDApacRow["evidence"]["confidence"]): string {
+  switch (c) {
+    case "high":
+      return "border-datum/40 bg-datum/10 text-ink";
+    case "medium":
+      return "border-ink/20 bg-white text-ink";
+    case "low":
+      return "border-accent/40 bg-accent/10 text-ink";
+  }
+}
+
+export default function ApacInvestmentTable() {
+  return (
+    <section className="surface-card p-6" id="apac-comparison">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <p className="eyebrow">International context</p>
+          <h2 className="mt-1 font-display text-2xl text-ink">
+            How NZ compares: APAC OECD members&apos; AI investment
+          </h2>
+        </div>
+        <a
+          href={OECD_APAC_META.baseSource.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-medium text-ink underline underline-offset-4"
+        >
+          {OECD_APAC_META.baseSource.label} ↗
+        </a>
+      </header>
+
+      <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+        The four OECD member countries in APAC have taken visibly different
+        positions on national AI investment. The figures below are headline
+        commitments - the amounts each government has publicly earmarked,
+        not amounts spent or independently evaluated. Use the per-capita
+        column to read scale relative to population, not as a forecast or
+        ranking.
+      </p>
+
+      <div className="mt-5 overflow-x-auto">
+        <table className="w-full min-w-[860px] border-collapse text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-[0.12em] text-steel">
+              <th scope="col" className="border-b border-ink/15 py-2 pr-3">
+                Country
+              </th>
+              <th scope="col" className="border-b border-ink/15 px-3 py-2">
+                National AI strategy
+              </th>
+              <th scope="col" className="border-b border-ink/15 px-3 py-2">
+                Headline AI investment
+              </th>
+              <th scope="col" className="border-b border-ink/15 px-3 py-2">
+                Approx. USD
+              </th>
+              <th scope="col" className="border-b border-ink/15 px-3 py-2">
+                Per capita
+              </th>
+              <th scope="col" className="border-b border-ink/15 px-3 py-2">
+                Evidence
+              </th>
+              <th scope="col" className="border-b border-ink/15 py-2 pl-3">
+                Source
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {OECD_APAC_ROWS.map((row) => (
+              <tr
+                key={row.code}
+                className={row.code === "NZ" ? "bg-ink/[0.03]" : undefined}
+              >
+                <th
+                  scope="row"
+                  className="border-b border-ink/10 py-3 pr-3 align-top"
+                >
+                  <span className="font-mono text-[11px] text-steel">
+                    {row.code}
+                  </span>
+                  <span className="ml-2 font-display text-base text-ink">
+                    {row.name}
+                  </span>
+                  <span className="mt-0.5 block text-[11px] text-steel">
+                    pop {row.populationMillions.toFixed(1)}M
+                  </span>
+                </th>
+                <td className="border-b border-ink/10 px-3 py-3 align-top text-ink">
+                  <span className="block">{row.strategy.name}</span>
+                  <span className="mt-0.5 block text-[11px] text-steel">
+                    {row.strategy.year}
+                  </span>
+                </td>
+                <td className="border-b border-ink/10 px-3 py-3 align-top text-ink">
+                  <span className="block font-medium">
+                    {row.investment.label}
+                  </span>
+                  <span className="mt-0.5 block text-[11px] text-steel">
+                    {row.investment.period}
+                  </span>
+                  <span className="mt-1 block text-[11px] leading-snug text-steel">
+                    {row.investment.scope}
+                  </span>
+                </td>
+                <td className="border-b border-ink/10 px-3 py-3 align-top font-mono text-xs tabular-nums text-ink">
+                  {formatUsd(row.investment.approxUsdMillions)}
+                </td>
+                <td className="border-b border-ink/10 px-3 py-3 align-top font-mono text-xs tabular-nums text-ink">
+                  {formatPerCapita(row)}
+                </td>
+                <td className="border-b border-ink/10 px-3 py-3 align-top">
+                  <span
+                    className={`inline-flex flex-col rounded-md border px-2 py-1 text-[11px] ${confidenceTone(row.evidence.confidence)}`}
+                  >
+                    <span className="font-medium capitalize">
+                      {row.evidence.class}
+                    </span>
+                    <span className="text-steel">
+                      {row.evidence.confidence} confidence
+                    </span>
+                  </span>
+                </td>
+                <td className="border-b border-ink/10 py-3 pl-3 align-top">
+                  <div className="grid gap-1">
+                    <a
+                      href={row.sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-ink underline underline-offset-4"
+                    >
+                      {row.sourceLabel} ↗
+                    </a>
+                    <a
+                      href={row.oecdAiUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[11px] text-steel underline underline-offset-4"
+                    >
+                      OECD AI dashboard ↗
+                    </a>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        {OECD_APAC_ROWS.map((row) => (
+          <details
+            key={`note-${row.code}`}
+            className="rounded-xl border border-ink/15 bg-white p-3 text-sm"
+          >
+            <summary className="cursor-pointer font-medium text-ink">
+              {row.name} - context
+            </summary>
+            <p className="mt-2 text-xs leading-relaxed text-steel">
+              {row.notes}
+            </p>
+          </details>
+        ))}
+      </div>
+
+      <aside
+        role="note"
+        className="mt-5 rounded-2xl border border-accent/40 bg-accent/10 p-4 text-xs leading-relaxed text-ink"
+      >
+        <p className="font-medium">How to read this table</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-steel">
+          <li>
+            Headline figures are <em>announcements</em>, not audited spend.
+            They cover different periods, scopes (R&amp;D vs adoption vs
+            compute), and accounting boundaries.
+          </li>
+          <li>
+            {OECD_APAC_META.fxNote} Treat USD totals as direction of
+            magnitude only.
+          </li>
+          <li>
+            Per-capita figures are derived from the headline envelope divided
+            by population - they do not adjust for purchasing power, FX
+            timing, or programme duration.
+          </li>
+          <li>
+            New Zealand has policy frameworks in place but no consolidated AI
+            investment envelope in current budgets, which is the gap this
+            sandbox helps stress-test.
+          </li>
+          <li>
+            Last reviewed {OECD_APAC_META.lastReviewed}. Refresh from the{" "}
+            <a
+              href={OECD_APAC_META.baseSource.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4"
+            >
+              OECD AI Policy Observatory
+            </a>{" "}
+            before reusing in published material.
+          </li>
+        </ul>
+      </aside>
+    </section>
+  );
+}

--- a/lib/oecd-apac.ts
+++ b/lib/oecd-apac.ts
@@ -1,0 +1,149 @@
+/**
+ * APAC OECD member countries: published AI investment commitments and
+ * national AI strategies, as catalogued by the OECD AI Policy Observatory.
+ *
+ * All figures are headline announcements - the dollar amount governments
+ * have publicly earmarked for AI, not amounts spent or evaluated. Currency
+ * conversions are approximate, taken from OECD AI dashboards or the source
+ * documents at the time of the announcement. Treat values as direction of
+ * magnitude for comparison, not point estimates.
+ *
+ * Evidence class on each row reflects the public commitment (observed),
+ * with confidence tagged per row. Refresh against OECD AI Policy
+ * Observatory country dashboards when adding a new content version.
+ */
+
+export type EvidenceClass = "observed" | "derived" | "expert" | "placeholder";
+export type Confidence = "low" | "medium" | "high";
+
+export interface OECDApacRow {
+  /** ISO 3166-1 alpha-2 code. */
+  code: "AU" | "JP" | "KR" | "NZ";
+  name: string;
+  /** Approximate population in millions (OECD Data, 2024 vintage). */
+  populationMillions: number;
+  /** Most prominent national AI strategy and year published or refreshed. */
+  strategy: { name: string; year: number };
+  /** Headline AI investment as publicly announced. */
+  investment: {
+    /** Short label shown in the table cell, e.g. "A$102.0M". */
+    label: string;
+    /** Period covered by the announcement. */
+    period: string;
+    /**
+     * Approximate USD equivalent for cross-country sizing.
+     * `null` where no consolidated AI budget envelope is reported.
+     */
+    approxUsdMillions: number | null;
+    /** Scope of the headline figure. */
+    scope: string;
+  };
+  evidence: { class: EvidenceClass; confidence: Confidence };
+  /** OECD AI Policy Observatory country dashboard URL. */
+  oecdAiUrl: string;
+  /** Primary source URL (official strategy doc or budget paper). */
+  sourceUrl: string;
+  sourceLabel: string;
+  /** One-line plain-English context, NZ English. */
+  notes: string;
+}
+
+export const OECD_APAC_ROWS: ReadonlyArray<OECDApacRow> = [
+  {
+    code: "AU",
+    name: "Australia",
+    populationMillions: 26.8,
+    strategy: { name: "Safe and Responsible AI agenda", year: 2024 },
+    investment: {
+      label: "A$102.0M",
+      period: "5 years from 2023-24",
+      approxUsdMillions: 68,
+      scope:
+        "Responsible AI uptake, National AI Centre, regulator capability",
+    },
+    evidence: { class: "observed", confidence: "medium" },
+    oecdAiUrl: "https://oecd.ai/en/dashboards/countries/Australia",
+    sourceUrl:
+      "https://www.industry.gov.au/news/government-response-safe-and-responsible-ai-australia-consultation",
+    sourceLabel: "DISR - Government response: Safe and Responsible AI",
+    notes:
+      "Funds the National AI Centre, the AI in Government Taskforce, and standards work. Defence AI and broader digital programmes sit outside this envelope.",
+  },
+  {
+    code: "JP",
+    name: "Japan",
+    populationMillions: 124.5,
+    strategy: {
+      name: "AI Strategy 2022 (annually updated) + Hiroshima AI Process",
+      year: 2022,
+    },
+    investment: {
+      label: "\u00a572.5B",
+      period: "FY2024 GENIAC programme",
+      approxUsdMillions: 470,
+      scope:
+        "Generative AI compute and foundation-model R&D (GENIAC)",
+    },
+    evidence: { class: "observed", confidence: "medium" },
+    oecdAiUrl: "https://oecd.ai/en/dashboards/countries/Japan",
+    sourceUrl: "https://www.meti.go.jp/english/press/2024/0202_002.html",
+    sourceLabel: "METI - GENIAC generative AI development support",
+    notes:
+      "Headline figure is METI's GENIAC compute and model-development envelope. Additional AIST and NEDO compute investments add further hundreds of billions of yen across multiple years.",
+  },
+  {
+    code: "KR",
+    name: "Korea",
+    populationMillions: 51.7,
+    strategy: {
+      name: "National AI Strategy (refreshed) + K-AI initiative",
+      year: 2023,
+    },
+    investment: {
+      label: "\u20a99.4T",
+      period: "Announced May 2024, to 2027",
+      approxUsdMillions: 7000,
+      scope:
+        "AI semiconductor R&D, compute infrastructure, talent, public-sector adoption",
+    },
+    evidence: { class: "observed", confidence: "medium" },
+    oecdAiUrl: "https://oecd.ai/en/dashboards/countries/Korea",
+    sourceUrl: "https://english.president.go.kr/briefing/Speeches/Wb6Q4kFc",
+    sourceLabel: "Office of the President - AI G3 Strategy briefing",
+    notes:
+      "Largest headline AI commitment in the APAC OECD set. Spans the AI-semiconductor fab programme (approximately \u20a91.4T) and the wider K-AI envelope to 2027.",
+  },
+  {
+    code: "NZ",
+    name: "New Zealand",
+    populationMillions: 5.2,
+    strategy: {
+      name: "MBIE Public Service AI Framework + AI Strategy",
+      year: 2024,
+    },
+    investment: {
+      label: "No consolidated AI budget envelope",
+      period: "Budgets 2023-2025",
+      approxUsdMillions: null,
+      scope:
+        "Policy frameworks, Algorithm Charter, sector-specific digital lines",
+    },
+    evidence: { class: "observed", confidence: "low" },
+    oecdAiUrl: "https://oecd.ai/en/dashboards/countries/New-Zealand",
+    sourceUrl:
+      "https://www.mbie.govt.nz/business-and-employment/economic-development/artificial-intelligence",
+    sourceLabel: "MBIE - Artificial Intelligence in New Zealand",
+    notes:
+      "No standalone AI funding programme appears in Budgets 2023-2025. Activity is spread across MBIE, DPMC, Stats NZ, and sector agencies, so a single comparable envelope is not reported. AI Forum NZ has flagged this gap in successive State of AI reports.",
+  },
+];
+
+export const OECD_APAC_META = {
+  lastReviewed: "2026-05-23",
+  baseSource: {
+    label: "OECD AI Policy Observatory - country dashboards",
+    url: "https://oecd.ai/en/dashboards/countries",
+  },
+  fxNote:
+    "USD equivalents are approximate, using the OECD AI Policy Observatory's reported conversions or central-bank reference rates at announcement date.",
+} as const;


### PR DESCRIPTION
## What

Adds a novice-friendly comparison of AI investment commitments across the four APAC OECD member countries (Australia, Japan, Korea, New Zealand) on the `/evidence` page.

## Why

Helps a non-specialist reader see how NZ sits in its regional OECD peer group on AI funding before engaging with the sandbox tradeoffs. Surfaces the gap that no NZ budget consolidates AI spending, which the sandbox helps stress-test.

## Each row shows

- National AI strategy + year published or refreshed
- Headline announced AI investment with period and scope
- Approx USD equivalent (with FX caveat)
- Per-capita USD (derived)
- Evidence class + confidence
- Links to the OECD AI Policy Observatory country dashboard **and** the primary source (official strategy or budget paper)

## Guardrails honoured

- All figures labelled as **announcements**, not audited spend, with scope and period spelled out per row.
- Every row carries an evidence class (`observed`) plus a confidence tag.
- NZ row deliberately reports "No consolidated AI budget envelope" rather than inventing a number, because Budgets 2023-2025 have no standalone AI line item.
- Sources: each row links to the OECD AI Policy Observatory dashboard plus the relevant primary source (DISR, METI, Office of the President KR, MBIE).
- Per-capita is labelled as a derived comparison aid, not a ranking.
- NZ English, spaced hyphens, no emoji, no forecasting claims.

## Files

- `lib/oecd-apac.ts` - typed data module (`OECDApacRow`, `OECD_APAC_ROWS`, `OECD_APAC_META`).
- `components/evidence/apac-investment-table.tsx` - server component: table + per-row context disclosures + "how to read this" caveat.
- `app/evidence/page.tsx` - mounts the new section between the evidence-classes card and the implementation-status card.

## Verification

- `npm run lint` clean.
- `npm run build` succeeds; 8 static routes generate as before (`/`, `/baseline`, `/compare`, `/evidence`, `/glossary`, `/how-it-works`, `/methodology`, `/_not-found`).
- No new dependencies.
