### PR TITLE
fix(oecd-apac): correct NZ OECD AI dashboard URL

### DIFF
--- a/lib/oecd-apac.ts
+++ b/lib/oecd-apac.ts
@@ -129,7 +129,7 @@ export const OECD_APAC_ROWS: ReadonlyArray<OECDApacRow> = [
         "Policy frameworks, Algorithm Charter, sector-specific digital lines",
     },
     evidence: { class: "observed", confidence: "low" },
-    oecdAiUrl: "https://oecd.ai/en/dashboards/countries/New-Zealand",
+    oecdAiUrl: "https://oecd.ai/en/dashboards/national/new-zealand",
     sourceUrl:
       "https://www.mbie.govt.nz/business-and-employment/economic-development/artificial-intelligence",
     sourceLabel: "MBIE - Artificial Intelligence in New Zealand",


### PR DESCRIPTION
Fixes the NZ row's OECD AI Policy Observatory dashboard URL on the `/evidence` APAC comparison table.

- Was: `https://oecd.ai/en/dashboards/countries/New-Zealand` (does not resolve)
- Now: `https://oecd.ai/en/dashboards/national/new-zealand`

Single-line change in `lib/oecd-apac.ts`.