### PR TITLE
ci: add PR-time typecheck/lint/build + reconcile tasks.md drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-${{ hashFiles('app/**/*.ts', 'app/**/*.tsx', 'components/**/*.ts', 'components/**/*.tsx', 'lib/**/*.ts', 'lib/**/*.tsx', 'next.config.*', 'tailwind.config.*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-${{ hashFiles('app/**/*.ts', 'app/**/*.tsx', 'components/**/*.ts', 'components/**/*.tsx', 'lib/**/*.ts', 'lib/**/*.tsx', 'next.config.*', 'tailwind.config.*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-${{ hashFiles('app/**/*.ts', 'app/**/*.tsx', 'components/**/*.ts', 'components/**/*.tsx', 'lib/**/*.ts', 'lib/**/*.tsx', 'next.config.*', 'tailwind.config.*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-${{ hashFiles('app/**/*.ts', 'app/**/*.tsx', 'components/**/*.ts', 'components/**/*.tsx', 'lib/**/*.ts', 'lib/**/*.tsx', 'next.config.*', 'tailwind.config.*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -297,6 +296,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1341,7 +1362,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1401,7 +1421,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1958,7 +1977,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2381,7 +2399,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3020,7 +3037,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3230,7 +3246,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4463,7 +4478,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5225,7 +5239,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -5384,7 +5397,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5394,7 +5406,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6209,7 +6220,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6379,7 +6389,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6680,7 +6689,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/specs/001-ai-policy-sandbox-app/tasks.md
+++ b/specs/001-ai-policy-sandbox-app/tasks.md
@@ -11,15 +11,15 @@
 
 **Purpose**: Create the Next.js + TypeScript + Tailwind/shadcn project foundation for the showcase app.
 
-- [ ] T001 Create Next.js package manifest with scripts and dependencies in package.json
-- [ ] T002 Create TypeScript configuration for the app in tsconfig.json
-- [ ] T003 Create Next.js configuration for static-friendly deployment in next.config.ts
-- [ ] T004 [P] Configure Tailwind CSS theme and content paths in tailwind.config.ts
-- [ ] T005 [P] Create global stylesheet with Tailwind layers and base tokens in app/globals.css
-- [ ] T006 [P] Configure linting for TypeScript and React in eslint.config.mjs
+- [x] T001 Create Next.js package manifest with scripts and dependencies in package.json
+- [x] T002 Create TypeScript configuration for the app in tsconfig.json
+- [x] T003 Create Next.js configuration for static-friendly deployment in next.config.ts (implemented as `next.config.mjs`)
+- [x] T004 [P] Configure Tailwind CSS theme and content paths in tailwind.config.ts
+- [x] T005 [P] Create global stylesheet with Tailwind layers and base tokens in app/globals.css
+- [x] T006 [P] Configure linting for TypeScript and React in eslint.config.mjs
 - [ ] T007 [P] Configure Vitest unit test environment in vitest.config.ts
 - [ ] T008 [P] Configure Playwright end-to-end test project in playwright.config.ts
-- [ ] T009 Create root app layout and metadata shell in app/layout.tsx
+- [x] T009 Create root app layout and metadata shell in app/layout.tsx
 
 ---
 
@@ -27,30 +27,32 @@
 
 **Purpose**: Establish data contracts, repo-backed content loading, shared UI primitives, and model utilities required by all user stories.
 
+> Note: implementation shipped JSON content files under `content/*.json` instead of the originally planned YAML paths.
+
 **Critical**: No user story work can begin until this phase is complete.
 
-- [ ] T010 Create shared TypeScript domain types in lib/schemas/types.ts
-- [ ] T011 [P] Implement Published Content Version Zod schema in lib/schemas/published-content.ts
-- [ ] T012 [P] Implement Policy Scenario Zod schema in lib/schemas/policy-scenario.ts
-- [ ] T013 [P] Implement Sector Zod schema with 19-sector aggregate coverage validation in lib/schemas/sector.ts
-- [ ] T014 [P] Implement Evidence Record Zod schema in lib/schemas/evidence-record.ts
-- [ ] T015 [P] Implement Approved Control Zod schema in lib/schemas/approved-control.ts
-- [ ] T016 [P] Implement Static Summary Export Zod schema in lib/schemas/static-summary-export.ts
-- [ ] T017 Implement repo-backed content loader and validation pipeline in lib/content/load-content.ts
-- [ ] T018 Create initial reviewed content version record in content/versions/2026-05-03-showcase.json
-- [ ] T019 [P] Create initial scenario archetype content in content/scenarios/showcase-scenarios.yaml
-- [ ] T020 [P] Create initial 19-sector tiered content in content/sectors/anzsic-sectors.yaml
-- [ ] T021 [P] Create initial evidence records for showcase assumptions in content/evidence/showcase-evidence.yaml
-- [ ] T022 [P] Create approved public controls content in content/controls/showcase-controls.yaml
-- [ ] T023 Implement comparison state helpers for browser-session-only state in lib/state/comparison-state.ts
-- [ ] T024 Implement core tradeoff calculation helpers using approved controls in lib/model/compare-scenarios.ts
-- [ ] T025 Implement comparability validation for budget, horizon, sector coverage, and scenario assumptions in lib/model/validate-comparison.ts
-- [ ] T026 Create shared non-forecast caveat text utilities in lib/content/caveats.ts
+- [x] T010 Create shared TypeScript domain types in lib/schemas/types.ts (consolidated in `lib/model/schemas.ts`)
+- [x] T011 [P] Implement Published Content Version Zod schema in lib/schemas/published-content.ts (implemented in `lib/model/schemas.ts`)
+- [x] T012 [P] Implement Policy Scenario Zod schema in lib/schemas/policy-scenario.ts (implemented in `lib/model/schemas.ts`)
+- [x] T013 [P] Implement Sector Zod schema with 19-sector aggregate coverage validation in lib/schemas/sector.ts (schema in `lib/model/schemas.ts`, coverage checks in `lib/model/content.ts`)
+- [x] T014 [P] Implement Evidence Record Zod schema in lib/schemas/evidence-record.ts (implemented in `lib/model/schemas.ts`)
+- [ ] T015 [P] Implement Approved Control Zod schema in lib/schemas/approved-control.ts (left: dedicated approved-control schema/module)
+- [ ] T016 [P] Implement Static Summary Export Zod schema in lib/schemas/static-summary-export.ts (left: static export schema/module)
+- [ ] T017 Implement repo-backed content loader and validation pipeline in lib/content/load-content.ts (partially covered by `lib/model/content.ts` for JSON parse + validation)
+- [x] T018 Create initial reviewed content version record in content/versions/2026-05-03-showcase.json (implemented as `content/version.json`)
+- [x] T019 [P] Create initial scenario archetype content in content/scenarios/showcase-scenarios.yaml (implemented as `content/scenarios.json`)
+- [x] T020 [P] Create initial 19-sector tiered content in content/sectors/anzsic-sectors.yaml (implemented as `content/sectors.json`)
+- [ ] T021 [P] Create initial evidence records for showcase assumptions in content/evidence/showcase-evidence.yaml (left: dedicated evidence registry file)
+- [ ] T022 [P] Create approved public controls content in content/controls/showcase-controls.yaml (left: dedicated controls content file)
+- [ ] T023 Implement comparison state helpers for browser-session-only state in lib/state/comparison-state.ts (state exists in `app/compare/page.tsx`, left: shared state helper module)
+- [x] T024 Implement core tradeoff calculation helpers using approved controls in lib/model/compare-scenarios.ts (implemented in `lib/model/compare.ts`)
+- [x] T025 Implement comparability validation for budget, horizon, sector coverage, and scenario assumptions in lib/model/validate-comparison.ts
+- [ ] T026 Create shared non-forecast caveat text utilities in lib/content/caveats.ts (caveat text currently lives in `components/compare/caveat-banner.tsx`)
 - [ ] T027 Create shadcn-compatible base UI components in components/ui/button.tsx
 - [ ] T028 [P] Create shadcn-compatible card component in components/ui/card.tsx
 - [ ] T029 [P] Create shadcn-compatible tabs component in components/ui/tabs.tsx
-- [ ] T030 [P] Create shadcn-compatible slider component in components/ui/slider.tsx
-- [ ] T031 [P] Create responsive app navigation shell in components/layout/app-shell.tsx
+- [x] T030 [P] Create shadcn-compatible slider component in components/ui/slider.tsx
+- [ ] T031 [P] Create responsive app navigation shell in components/layout/app-shell.tsx (header/footer exist, left: `app-shell.tsx` wrapper)
 
 **Checkpoint**: Content contracts, validation, shared UI, and model helpers are ready for story implementation.
 
@@ -64,16 +66,16 @@
 
 ### Implementation for User Story 1
 
-- [ ] T032 [P] [US1] Create public landing page that routes users into the sandbox in app/page.tsx
-- [ ] T033 [P] [US1] Create scenario selection component in components/compare/scenario-selector.tsx
-- [ ] T034 [P] [US1] Create budget and time horizon controls in components/compare/budget-horizon-controls.tsx
-- [ ] T035 [P] [US1] Create approved uncertainty range controls in components/compare/uncertainty-controls.tsx
-- [ ] T036 [US1] Implement comparison workspace page using session-only state in app/compare/page.tsx
-- [ ] T037 [P] [US1] Create tradeoff summary panel in components/compare/tradeoff-summary.tsx
-- [ ] T038 [P] [US1] Create ECharts tradeoff chart component in components/charts/tradeoff-chart.tsx
-- [ ] T039 [P] [US1] Create comparability warning component in components/compare/comparability-warning.tsx
-- [ ] T040 [US1] Integrate non-forecast framing and caveat text in components/compare/tradeoff-summary.tsx
-- [ ] T041 [US1] Ensure public controls cannot mutate authoritative content in lib/state/comparison-state.ts
+- [x] T032 [P] [US1] Create public landing page that routes users into the sandbox in app/page.tsx
+- [ ] T033 [P] [US1] Create scenario selection component in components/compare/scenario-selector.tsx (implemented inside `policy-lab-panel.tsx`, left: split into dedicated component)
+- [ ] T034 [P] [US1] Create budget and time horizon controls in components/compare/budget-horizon-controls.tsx (implemented inside `policy-lab-panel.tsx`, left: split into dedicated component)
+- [ ] T035 [P] [US1] Create approved uncertainty range controls in components/compare/uncertainty-controls.tsx (implemented inside `policy-lab-panel.tsx`, left: split into dedicated component)
+- [x] T036 [US1] Implement comparison workspace page using session-only state in app/compare/page.tsx
+- [ ] T037 [P] [US1] Create tradeoff summary panel in components/compare/tradeoff-summary.tsx (similar card output in `scenario-results-card.tsx`, left: dedicated summary component)
+- [ ] T038 [P] [US1] Create ECharts tradeoff chart component in components/charts/tradeoff-chart.tsx (left: migrate current custom SVG charts to ECharts tradeoff chart)
+- [x] T039 [P] [US1] Create comparability warning component in components/compare/comparability-warning.tsx
+- [ ] T040 [US1] Integrate non-forecast framing and caveat text in components/compare/tradeoff-summary.tsx (framing exists via `caveat-banner.tsx`, left: integrate in dedicated summary component)
+- [ ] T041 [US1] Ensure public controls cannot mutate authoritative content in lib/state/comparison-state.ts (behaviour appears in page-level state flow, left: move/enforce in shared `comparison-state.ts`)
 
 **Checkpoint**: User Story 1 is independently functional as the MVP comparison workspace.
 
@@ -91,10 +93,10 @@
 - [ ] T043 [P] [US2] Create evidence badge component for observed, derived, expert, placeholder, and assumed classes in components/evidence/evidence-badge.tsx
 - [ ] T044 [P] [US2] Create evidence detail drawer in components/evidence/evidence-detail-drawer.tsx
 - [ ] T045 [US2] Add sector and evidence drill-down interactions to app/compare/page.tsx
-- [ ] T046 [P] [US2] Create evidence index page in app/evidence/page.tsx
-- [ ] T047 [P] [US2] Implement published content version display in components/evidence/content-version-banner.tsx
+- [x] T046 [P] [US2] Create evidence index page in app/evidence/page.tsx
+- [ ] T047 [P] [US2] Implement published content version display in components/evidence/content-version-banner.tsx (version is currently shown in `components/compare/caveat-banner.tsx`)
 - [ ] T048 [US2] Surface weak, placeholder, assumed, and low-confidence evidence caveats in components/evidence/evidence-detail-drawer.tsx
-- [ ] T049 [US2] Enforce last-published reviewed content behaviour in lib/content/load-content.ts
+- [ ] T049 [US2] Enforce last-published reviewed content behaviour in lib/content/load-content.ts (left: explicit reviewed publication pipeline)
 
 **Checkpoint**: User Story 2 is independently verifiable through sector and evidence inspection.
 
@@ -115,7 +117,7 @@
 - [ ] T054 [P] [US3] Create export summary button and status UI in components/compare/export-summary-button.tsx
 - [ ] T055 [US3] Integrate static summary export into comparison workspace in app/compare/page.tsx
 - [ ] T056 [US3] Validate exported summary content with Zod in lib/export/static-summary.ts
-- [ ] T057 [US3] Confirm browser-session-only reset behaviour in lib/state/comparison-state.ts
+- [ ] T057 [US3] Confirm browser-session-only reset behaviour in lib/state/comparison-state.ts (state reset exists in page local state, left: shared module-level confirmation)
 
 **Checkpoint**: User Story 3 is independently verifiable through sensitivity exploration and static export.
 
@@ -125,17 +127,17 @@
 
 **Purpose**: Validate end-to-end quality, documentation, accessibility, and deployment readiness across all stories.
 
-- [ ] T058 [P] Create methodology page explaining sandbox framing and limits in app/methodology/page.tsx
+- [x] T058 [P] Create methodology page explaining sandbox framing and limits in app/methodology/page.tsx
 - [ ] T059 [P] Add quickstart usage notes for public showcase users in README.md
 - [ ] T060 [P] Add content authoring guidance for analysts in docs/showcase-content-workflow.md
 - [ ] T061 Create unit coverage for schemas and model utilities in tests/unit/model-and-schema.test.ts
 - [ ] T062 Create contract validation coverage for repo-backed content in tests/contract/content-contracts.test.ts
 - [ ] T063 Create Playwright flow covering comparison, evidence inspection, export, and session-only reset in tests/e2e/public-sandbox.spec.ts
 - [ ] T064 Run quickstart validation commands and record gaps in specs/001-ai-policy-sandbox-app/quickstart.md
-- [ ] T065 Run build validation for the Next.js app using package.json scripts
-- [ ] T066 Audit UI copy for non-forecast framing and NZ English in app/compare/page.tsx
-- [ ] T067 Audit responsive layout and chart readability in components/charts/tradeoff-chart.tsx
-- [ ] T068 Run TypeScript strict type-safety validation for policy-critical paths using package.json scripts
+- [x] T065 Run build validation for the Next.js app using package.json scripts
+- [x] T066 Audit UI copy for non-forecast framing and NZ English in app/compare/page.tsx
+- [ ] T067 Audit responsive layout and chart readability in components/charts/tradeoff-chart.tsx (left: formal audit evidence and ECharts component)
+- [x] T068 Run TypeScript strict type-safety validation for policy-critical paths using package.json scripts
 - [ ] T069 Validate public performance goals for first view, comparison update, and static export in tests/e2e/public-sandbox.spec.ts using Playwright desktop and mobile profiles with documented network and CPU throttling assumptions
 - [ ] T070 Audit UX uniformity for navigation, controls, caveats, and responsive accessibility across app/ and components/
 


### PR DESCRIPTION
## Summary
- add a PR-time GitHub Actions workflow at `.github/workflows/ci.yml` that runs on `pull_request` and `push` to `main`
- run install, typecheck, lint, and build as separate jobs using `actions/checkout@v5` and `actions/setup-node@v5`
- enable run cancellation for superseded PR updates via workflow concurrency
- cache npm dependencies (via setup-node cache) and Next.js build cache (`.next/cache`)

## tasks.md reconciliation
- reconciled `specs/001-ai-policy-sandbox-app/tasks.md` against shipped artefacts and marked clearly completed tasks as `[x]`
- added conservative one-line notes where implementation differs from original file paths or is partially done
- recorded that JSON content files in `content/*.json` replaced planned YAML paths

## Still pending in tasks.md
- test stack setup remains open (`T007` Vitest, `T008` Playwright)
- dedicated schema/content modules from the original layout remain open where implementation was consolidated (`T015`, `T016`, `T017`, `T021`, `T022`, `T023`, `T026`)
- US2 and US3 drill-down/export work remains largely open (`T042` to `T057`, excluding `T046`)
- cross-cutting test and polish tasks remain open (`T059` to `T064`, `T067`, `T069`, `T070`)

## Local verification
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

All passed locally.
