### PR TITLE
feat: testing framework + comparison workspace landing UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,47 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  test:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: End-to-end tests
+        run: npm run test:e2e
+
   build:
     runs-on: ubuntu-latest
     needs: install

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/
+
 # Local environment overrides
 .env.local
 .env.development.local

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import CaveatBanner from "@/components/compare/caveat-banner";
 import ComparabilityWarning from "@/components/compare/comparability-warning";
@@ -25,6 +25,9 @@ const SCENARIO_CHIPS: readonly ScenarioChip[] = CONTENT.scenarios
   .map((s) => ({ id: s.id, name: s.name, description: s.description }));
 
 const SCENARIO_IDS = new Set(SCENARIO_CHIPS.map((s) => s.id));
+
+const SCENARIO_NAME_BY_ID = new Map(CONTENT.scenarios.map((s) => [s.id, s.name]));
+const REFERENCE_NAME = SCENARIO_NAME_BY_ID.get(REFERENCE_ID) ?? "Status quo";
 
 /** Encode the full config into a URL query string. */
 function encodeConfig(c: PolicyLabConfig): string {
@@ -85,6 +88,7 @@ export default function ComparePage() {
   const [staged, setStaged] = useState<PolicyLabConfig>(CALIBRATED_CONFIG);
   const [applied, setApplied] = useState<PolicyLabConfig>(CALIBRATED_CONFIG);
   const [shareLabel, setShareLabel] = useState<string>("Copy share link");
+  const shareTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [, startTransition] = useTransition();
 
   // Hydrate from URL on mount. This is the textbook "read from an external
@@ -115,6 +119,18 @@ export default function ComparePage() {
     );
   }, [applied, validation.comparable]);
 
+  const appliedScenarioNames = applied.selectedScenarioIds.map(
+    (id) => SCENARIO_NAME_BY_ID.get(id) ?? id,
+  );
+  const appliedScenarioSummary =
+    appliedScenarioNames.length === 0
+      ? "no scenarios selected"
+      : appliedScenarioNames.length === 1
+        ? appliedScenarioNames[0]
+        : `${appliedScenarioNames.slice(0, -1).join(", ")} and ${
+            appliedScenarioNames[appliedScenarioNames.length - 1]
+          }`;
+
   const handleRun = () => {
     startTransition(() => {
       setApplied(staged);
@@ -144,8 +160,17 @@ export default function ComparePage() {
     } catch {
       setShareLabel("Copy failed - select URL bar");
     }
-    setTimeout(() => setShareLabel("Copy share link"), 2000);
+    if (shareTimer.current) clearTimeout(shareTimer.current);
+    shareTimer.current = setTimeout(() => setShareLabel("Copy share link"), 2000);
   };
+
+  // Clear any pending share-label reset on unmount.
+  useEffect(
+    () => () => {
+      if (shareTimer.current) clearTimeout(shareTimer.current);
+    },
+    [],
+  );
 
   return (
     <main className="mx-auto w-full max-w-6xl px-6 py-10 md:px-10 md:py-14">
@@ -168,11 +193,22 @@ export default function ComparePage() {
         today&apos;s values forward unchanged.
       </p>
 
+      <p className="mt-4 rounded-xl border border-ink/15 bg-white/60 px-4 py-3 text-sm text-ink">
+        <span className="font-semibold">Now showing:</span>{" "}
+        {appliedScenarioSummary} vs {REFERENCE_NAME.toLowerCase()}, NZ$
+        {applied.budgetEnvelope}M over {applied.horizonYears}
+        {" "}years.{" "}
+        <a href="#results" className="font-medium text-ink underline underline-offset-4">
+          Jump to results &darr;
+        </a>
+      </p>
+
       <CaveatBanner />
 
       <section className="mt-6">
         <PolicyLabPanel
           scenarios={SCENARIO_CHIPS}
+          referenceName={REFERENCE_NAME}
           staged={staged}
           applied={applied}
           onChange={setStaged}
@@ -187,6 +223,7 @@ export default function ComparePage() {
         <ComparabilityWarning messages={validation.messages} />
       </section>
 
+      <div id="results" className="scroll-mt-24">
       {comparison ? (
         <>
           <section className="mt-6 grid gap-4 lg:grid-cols-2">
@@ -227,7 +264,18 @@ export default function ComparePage() {
             ))}
           </section>
         </>
-      ) : null}
+      ) : (
+        <section className="surface-card mt-6 p-6 text-sm text-steel">
+          <h2 className="font-display text-2xl text-ink">No comparable run yet</h2>
+          <p className="mt-2">
+            The current selections cannot be compared like-for-like. Resolve the
+            point(s) flagged above - typically by selecting at least one scenario
+            and keeping the shared budget and horizon - then the charts and
+            scenario cards will appear here.
+          </p>
+        </section>
+      )}
+      </div>
 
       <section className="surface-card mt-6 p-6 text-sm text-steel">
         <h2 className="font-display text-2xl text-ink">How to read these cards</h2>

--- a/app/evidence/page.tsx
+++ b/app/evidence/page.tsx
@@ -2,6 +2,9 @@ import ApacInvestmentTable from "@/components/evidence/apac-investment-table";
 import PageHeader from "@/components/layout/page-header";
 import { EVIDENCE_CLASSES } from "@/lib/reference-data";
 
+const RNZ_URL =
+  "https://www.rnz.co.nz/news/political/595655/nearly-9000-public-sector-jobs-to-go-government-agencies-to-merge-nicola-willis-announces";
+
 export default function EvidencePage() {
   return (
     <main className="mx-auto w-full max-w-6xl px-6 py-10 md:px-10 md:py-14">
@@ -23,6 +26,68 @@ export default function EvidencePage() {
             </li>
           ))}
         </ul>
+      </section>
+
+      <section className="mt-6 surface-card border-l-4 border-l-accent p-6">
+        <p className="eyebrow !text-accent">Featured signal</p>
+        <h2 className="mt-1 font-display text-2xl text-ink">
+          Public-sector productivity vs labour pressure
+        </h2>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+          The May 2026 plan to reduce the public-sector workforce and lean on AI to
+          maintain services is the clearest current example of a productivity dividend
+          being banked in advance. We hold it as a calibration anchor for the labour
+          adjustment trajectory (L) of the Public Sector (ANZSIC O), so the
+          productivity-versus-jobs tradeoff can be stress-tested rather than assumed. It
+          is a policy-target path, not a structural forecast.
+        </p>
+
+        <dl className="mt-4 grid gap-x-6 gap-y-3 rounded-xl border border-ink/10 bg-white/60 p-4 sm:grid-cols-2">
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-steel">Anchor</dt>
+            <dd className="mt-0.5 text-sm text-ink">
+              Public Administration FTE trajectory (Dec 2025 to Jul 2029)
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-steel">Implied change</dt>
+            <dd className="mt-0.5 text-sm text-ink">
+              ~ -2,500 FTE/yr (plausible range -2,200 to -2,800)
+            </dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-steel">Basis</dt>
+            <dd className="mt-0.5 text-sm text-ink">
+              63,657 FTE (Dec 2025) to 55,000 (Jul 2029), annualised
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-xs font-semibold text-ink">
+            Evidence class: derived
+          </span>
+          <span className="rounded-full border border-ink/20 bg-canvas px-3 py-1 text-xs font-semibold text-steel">
+            Confidence: medium
+          </span>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+          <a
+            href={RNZ_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-ink underline underline-offset-4"
+          >
+            Source: Willis announcement, RNZ, 24 May 2026
+          </a>
+          <a
+            href="/how-it-works#why-now"
+            className="font-medium text-steel underline underline-offset-4 hover:text-ink"
+          >
+            How the sandbox reads this signal
+          </a>
+        </div>
       </section>
 
       <div className="mt-6">

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -2,8 +2,25 @@ import Link from "next/link";
 
 import ConceptCard from "@/components/explainer/concept-card";
 import EquationCard from "@/components/explainer/equation-card";
+import OnThisPage, { type OnThisPageItem } from "@/components/explainer/on-this-page";
+import SystemDiagram from "@/components/explainer/system-diagram";
 import PageHeader from "@/components/layout/page-header";
 import { CONTENT } from "@/lib/model/content";
+
+const RNZ_URL =
+  "https://www.rnz.co.nz/news/political/595655/nearly-9000-public-sector-jobs-to-go-government-agencies-to-merge-nicola-willis-announces";
+
+const NAV_ITEMS: OnThisPageItem[] = [
+  { id: "why", label: "The goal" },
+  { id: "big-idea", label: "The big idea" },
+  { id: "five-things", label: "Five things tracked" },
+  { id: "build-and-wear", label: "How it adds up" },
+  { id: "equations", label: "The equations" },
+  { id: "tiers", label: "Three tiers" },
+  { id: "scenarios", label: "Policy scenarios" },
+  { id: "why-now", label: "Why it matters now" },
+  { id: "limits", label: "Honest limits" },
+];
 
 const TLDR = [
   "It is a comparison tool, not a forecast. You set policy levers; it shows how they trade off.",
@@ -31,9 +48,9 @@ const STATE_VARIABLES = [
     symbol: "E",
     name: "National enabling capacity",
     story:
-      "The whole-of-nation conditions every sector relies on: skills in the workforce, infrastructure, public trust, and the rules of the road for AI use.",
+      "The whole-of-nation conditions every sector relies on: skills in the workforce, infrastructure, public trust, and the standards and rules governing AI use.",
     analogy:
-      "the shared road network the whole country drives on - sealed surfaces, signage, rules, fuel stations, and a population that knows how to drive. Every sector's traffic uses it.",
+      "the national electricity grid the whole country plugs into - generation, lines, standards, and a workforce that knows how to use power. Every sector draws on it.",
     badge: "shared",
   },
   {
@@ -42,7 +59,7 @@ const STATE_VARIABLES = [
     story:
       "How ready a sector is to actually use AI: in-house skills, data maturity, and processes that can absorb new tools.",
     analogy:
-      "that sector's on-ramp onto the network. A wide, open on-ramp lets traffic flow on. A narrow or closed on-ramp holds it back, no matter how many drivers want to go.",
+      "that sector being wired up and ready - the switchboard, safe wiring, and trained staff. Until it is wired, extra power on the grid changes nothing for that sector.",
     badge: "per sector",
   },
   {
@@ -51,7 +68,7 @@ const STATE_VARIABLES = [
     story:
       "How much AI is actually in genuine operational use in a sector - not pilots, not press releases.",
     analogy:
-      "cars actually out on the network for that sector. Adoption needs an open on-ramp; close it and cars idle and back up.",
+      "how much of the sector's work is actually running on power. Wiring has to come first; without it, the machines sit idle no matter how much power is available.",
     badge: "per sector",
   },
   {
@@ -60,7 +77,7 @@ const STATE_VARIABLES = [
     story:
       "The productivity gain genuinely delivered. It sits below the theoretical ceiling and only grows as adoption matures.",
     analogy:
-      "the average speed of that sector's traffic. More cars using the lanes well means everyone's trip gets faster.",
+      "the extra output that electrified work delivers. It builds as more work runs on power, and fades if the power is switched back off.",
     badge: "per sector",
   },
   {
@@ -69,7 +86,7 @@ const STATE_VARIABLES = [
     story:
       "Strain on workers and labour markets as tasks are reorganised, automated, or augmented when AI spreads.",
     analogy:
-      "stress on drivers and depots when traffic rises. Heavier flows mean more rostering, retraining, and reorganising behind the scenes.",
+      "the strain of reorganising the workforce as machines take on tasks - retraining, redeploying, and rewriting roles. It rises as more work moves onto power.",
     badge: "per sector",
   },
 ];
@@ -78,17 +95,17 @@ const TIER_RIBBON = [
   {
     label: "Tier 1 - 9 sectors",
     text: "Full picture: capability, adoption, productivity, and labour pressure all tracked. Covers about 61% of GDP.",
-    analogy: "state highways - every lane, ramp, and sign drawn in.",
+    analogy: "fully wired regions - every circuit, meter, and load mapped.",
   },
   {
     label: "Tier 2 - 6 sectors",
     text: "Simpler picture: adoption and productivity, with labour pressure reported alongside.",
-    analogy: "regional roads - on the map with fewer markings.",
+    analogy: "partly mapped regions - the main connections, fewer details.",
   },
   {
     label: "Tier 3 - 4 sectors",
     text: "Minimum picture: adoption only. Included so the whole economy adds up honestly.",
-    analogy: "back roads - named so the country adds up, not the focus.",
+    analogy: "metered but not detailed - counted so the national total adds up.",
   },
 ];
 
@@ -98,9 +115,9 @@ const EQUATIONS = [
     reference: "dE/dt",
     formula: "dE/dt = (1 - E) * rho_E * G_E   -   E * rho_E * delta_E",
     story:
-      "The shared road network gets better when the country invests in skills, infrastructure, trust, and rules. It degrades slowly on its own through wear and obsolescence.",
+      "The shared grid improves when the country invests in skills, infrastructure, trust, and rules. It runs down slowly on its own through wear and obsolescence.",
     analogy:
-      "sealing the national road network. Crews (G_E) add sealed surface; weather and time wear it back down (delta_E). The closer to fully sealed, the slower each new crew makes a difference.",
+      "extending and upgrading the national grid. Crews (G_E) add capacity; age and obsolescence wear it back (delta_E). The closer to fully built, the less each new crew adds.",
   },
   {
     name: "Absorptive capability (Tier 1)",
@@ -108,18 +125,18 @@ const EQUATIONS = [
     formula:
       "dK/dt = (1 - K) * rho_K * ( phi_s*E  +  G_s  +  eta_s*A )   -   K * rho_K * mu_s",
     story:
-      "A sector's on-ramp gets wider when the shared network is in good shape (phi_s * E), when the sector receives targeted help (G_s), and when adoption is already creating pull (eta_s * A). It narrows over time from skill turnover and tool obsolescence (mu_s).",
+      "A sector gets wired up faster when the shared grid is strong (phi_s * E), when it receives targeted help (G_s), and when existing use is already pulling it along (eta_s * A). Wiring degrades over time through skill turnover and tool obsolescence (mu_s).",
     analogy:
-      "widening that sector's on-ramp. Better shared roads, direct roadworks for this sector, and existing traffic all help. Without maintenance, the on-ramp narrows back.",
+      "wiring up a sector. A strong grid, direct help for this sector, and work already on power all speed it up. Without upkeep, the wiring degrades.",
   },
   {
     name: "AI adoption (Tier 1)",
     reference: "dA/dt",
     formula: "dA/dt = (1 - A) * rho_A * alpha_s * K   -   A * rho_A * (1 - K)",
     story:
-      "Adoption grows when the on-ramp is open (high K). When the on-ramp is poor (low K), existing adoption stalls or reverses.",
+      "Use grows when the sector is well wired (high K). When the wiring is poor (low K), existing use stalls or switches back off.",
     analogy:
-      "cars merging on. An open on-ramp lets traffic flow on; a narrow one makes cars peel away.",
+      "switching work onto power. Good wiring lets more machines run; poor wiring trips the circuit and work drops back.",
   },
   {
     name: "Realised productivity",
@@ -128,7 +145,7 @@ const EQUATIONS = [
     story:
       "Productivity gains build up as adoption matures. If adoption drops back, the gains fade rather than persisting on their own.",
     analogy:
-      "average traffic speed. Speed rises once cars are using the lanes well; it drops when cars leave or a lane closes.",
+      "the extra output from electrified work. It rises as more work runs on power, and falls when the power goes off.",
   },
   {
     name: "Labour adjustment pressure (Tier 1)",
@@ -137,7 +154,7 @@ const EQUATIONS = [
     story:
       "Pressure on workers and labour markets rises with adoption and eases when adoption plateaus or reverses. Lambda_s captures how exposed each sector's workforce is.",
     analogy:
-      "stress on drivers and depots. Traffic up - more rosters, more retraining, more reorganising. Traffic down - the system relaxes.",
+      "the strain of reorganising around machines. More work on power means more retraining and redeployment; less work, less strain.",
   },
 ];
 
@@ -147,38 +164,38 @@ const SCENARIOS = [
     name: "Status quo",
     story:
       "No new policy effort. Today's values carry forward. This is the reference every other scenario is compared against.",
-    analogy: "no new roadworks budget - keep the network as it is.",
+    analogy: "no new grid or wiring budget - leave the network as it is.",
   },
   {
     symbol: "A",
     name: "Aggregate",
     story: "Spread the same budget evenly across every sector. A little for everyone, no targeting.",
     analogy:
-      "send a small crew to every on-ramp in the country - a bit of work everywhere, nothing focused.",
+      "a small wiring crew sent to every sector - a little everywhere, nothing focused.",
   },
   {
     symbol: "B",
     name: "Targeted demand",
     story:
-      "Direct the budget to sectors with low current adoption. Help where the on-ramps are narrowest.",
+      "Direct the budget to sectors with low current adoption. Help where sectors are least wired up.",
     analogy:
-      "send the crews straight to the narrowest, most clogged on-ramps first.",
+      "send the crews to the least-wired sectors first.",
   },
   {
     symbol: "C",
     name: "Targeted supply",
     story:
-      "Invest the budget in the shared road network itself - national skills, infrastructure, trust, regulation.",
+      "Invest the budget in the shared grid itself - national skills, infrastructure, trust, regulation.",
     analogy:
-      "pour the budget into the shared network - sealing, signage, driver training - rather than any single on-ramp.",
+      "pour the budget into the shared grid - skills, infrastructure, trust, rules - rather than any single sector.",
   },
   {
     symbol: "D",
     name: "Mixed",
     story:
-      "Split the budget between the shared network and targeted demand-side help.",
+      "Split the budget between the shared grid and targeted demand-side help.",
     analogy:
-      "half on the shared network, half on the worst on-ramps.",
+      "half into the shared grid, half into wiring up the least-ready sectors.",
   },
 ];
 
@@ -200,16 +217,18 @@ export default function HowItWorksPage() {
 
       <section className="mt-6 grid gap-4 md:grid-cols-[1.2fr_0.8fr]">
         <article className="surface-card p-6">
-          <p className="eyebrow">In 30 seconds</p>
+          <p className="eyebrow">The goal, in one line</p>
           <h2 className="mt-1 font-display text-2xl text-ink">
-            A driving simulator for AI policy in Aotearoa
+            Compare AI policy options for Aotearoa, honestly
           </h2>
           <p className="mt-3 text-sm leading-relaxed text-steel">
-            Picture the economy as a road network. Each sector has its own on-ramp onto
-            a shared national network. You choose how to spend the roadworks budget; the
-            model shows how traffic differs. It is a thinking tool, not a crystal ball.
-            We do not say what <em>will</em> happen - we show how options differ when
-            you make the same assumptions visible.
+            Different surveys put New Zealand&apos;s AI use anywhere from 32% to 87%.
+            With the evidence that scattered, no one can credibly say which policy will
+            help most. This sandbox gives you a transparent way to compare policy
+            approaches side by side - same assumptions, same budget, same horizon - so
+            the tradeoffs are visible instead of hidden. It is a thinking tool, not a
+            crystal ball: it shows how options <em>differ</em>, never what <em>will</em>
+            {" "}happen.
           </p>
         </article>
         <article className="surface-card p-6">
@@ -224,40 +243,48 @@ export default function HowItWorksPage() {
         </article>
       </section>
 
-      <section id="why" className="mt-8 surface-card p-6 scroll-mt-24">
-        <p className="eyebrow">Why we built it</p>
-        <h2 className="mt-1 font-display text-2xl text-ink">
-          AI policy is being shaped without a shared picture
-        </h2>
-        <div className="mt-4 grid gap-4 md:grid-cols-3">
-          {WHY_POINTS.map((w) => (
-            <div key={w.title} className="rounded-md border border-ink/10 bg-white/60 p-4">
-              <p className="font-semibold text-ink">{w.title}</p>
-              <p className="mt-1 text-sm leading-relaxed text-steel">{w.text}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+      <div className="mt-8 grid gap-8 lg:grid-cols-[210px_minmax(0,1fr)]">
+        <OnThisPage items={NAV_ITEMS} />
 
-      <section id="big-idea" className="mt-8 surface-card p-6 scroll-mt-24">
-        <p className="eyebrow">The big idea</p>
-        <h2 className="mt-1 font-display text-2xl text-ink">
-          A driving simulator for AI policy
-        </h2>
-        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
-          Picture New Zealand&apos;s economy as a road network. Each sector has its own
-          on-ramp onto a shared national network. Cars are AI use, lanes are capability,
-          and average traffic speed is the productivity payoff. The whole picture - on-ramps,
-          cars, speed, the network itself - is what this sandbox keeps in view.
-        </p>
-        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
-          Policy is a roadworks budget. You can spread crews thinly across every region,
-          send them to the worst on-ramps, or invest in the shared network. Same budget,
-          same time horizon, different mix - that is what makes the options comparable.
-          Every result is a comparison between mixes, never a forecast of next year&apos;s
-          traffic count.
-        </p>
-      </section>
+        <div className="min-w-0">
+          <section id="why" className="surface-card p-6 scroll-mt-24">
+            <p className="eyebrow">Why we built it</p>
+            <h2 className="mt-1 font-display text-2xl text-ink">
+              AI policy is being shaped without a shared picture
+            </h2>
+            <div className="mt-4 grid gap-4 md:grid-cols-3">
+              {WHY_POINTS.map((w) => (
+                <div key={w.title} className="rounded-md border border-ink/10 bg-white/60 p-4">
+                  <p className="font-semibold text-ink">{w.title}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-steel">{w.text}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section id="big-idea" className="mt-8 surface-card p-6 scroll-mt-24">
+            <p className="eyebrow">The big idea</p>
+            <h2 className="mt-1 font-display text-2xl text-ink">
+              An electricity grid for AI policy
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+              Picture New Zealand&apos;s economy as a country getting electrified. There
+              is one shared national grid - skills, infrastructure, trust, and the
+              standards and rules for AI - and every sector has to be wired up before it
+              can draw on it. Wiring a sector is its capability, work actually running on
+              power is adoption, and the extra output that electrified work delivers is
+              the productivity payoff.
+            </p>
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+              Policy is the budget for building the grid and wiring sectors up. You can
+              spread wiring crews thinly across every sector, send them to the least-ready
+              sectors, or invest in the shared grid itself. Same budget, same time
+              horizon, different mix - that is what makes the options comparable. Every
+              result is a comparison between mixes, never a forecast of next year&apos;s
+              output.
+            </p>
+            <SystemDiagram variant="full" className="mt-6" />
+          </section>
 
       <section id="five-things" className="mt-8 scroll-mt-24">
         <header className="mb-3">
@@ -292,32 +319,33 @@ export default function HowItWorksPage() {
         </h2>
         <div className="mt-4 grid gap-4 md:grid-cols-[1fr_1fr]">
           <p className="text-sm leading-relaxed text-steel">
-            Every equation in the model behaves like a section of road being built and
-            worn. Construction crews add lanes - faster when there is still plenty of
-            room to add, slower as the road approaches fully built. Meanwhile weather
-            and use wear the road back down at a rate that depends on how built it
-            already is.
+            Every equation in the model behaves like a piece of the grid being built and
+            worn. Construction crews add capacity - faster when there is still plenty of
+            room to add, slower as it approaches fully built. Meanwhile age and use wear
+            it back down at a rate that depends on how built it already is.
           </p>
           <p className="text-sm leading-relaxed text-steel">
-            That is why every quantity stays between 0 (no road) and 1 (fully built) by
-            construction. You will not see adoption above 100% or productivity below
+            That is why every quantity stays between 0 (nothing built) and 1 (fully built)
+            by construction. You will not see adoption above 100% or productivity below
             zero. The shape is the same for every equation; only what counts as a
             “crew” and what counts as “wear” changes.
           </p>
         </div>
       </section>
 
-      <section id="equations" className="mt-8 scroll-mt-24">
+      <section id="equations" className="mt-8 scroll-mt-24 rounded-2xl border border-ink/15 border-l-4 border-l-accent bg-white/50 p-6">
         <header className="mb-3">
-          <p className="eyebrow">The equations, in plain English</p>
+          <p className="eyebrow !text-accent">Going deeper - optional</p>
           <h2 className="mt-1 font-display text-2xl text-ink">
-            What each formula is saying
+            The equations, in plain English
           </h2>
           <p className="mt-2 max-w-3xl text-sm leading-relaxed text-steel">
-            The boxed lines are the actual v0.3 equations the engine runs. The story
-            underneath is what each one is doing in everyday words. Symbols starting with
-            rho, alpha, kappa, lambda, phi, eta, mu, beta, delta are sector-specific
-            speed and sensitivity dials calibrated from evidence.
+            You do not need this part to use the sandbox - it is here for anyone who
+            wants to see under the bonnet. The boxed lines are the actual v0.3 equations
+            the engine runs. The story underneath is what each one is doing in everyday
+            words. Symbols starting with rho, alpha, kappa, lambda, phi, eta, mu, beta,
+            delta are sector-specific speed and sensitivity dials calibrated from
+            evidence.
           </p>
         </header>
         <div className="grid gap-4 md:grid-cols-2">
@@ -344,13 +372,13 @@ export default function HowItWorksPage() {
       <section id="tiers" className="mt-8 surface-card p-6 scroll-mt-24">
         <p className="eyebrow">Why three tiers</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
-          A road atlas of the economy
+          A wiring map of the economy
         </h2>
         <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
           Not every sector has the same depth of evidence behind it. Instead of pretending
-          they do, we group sectors into three tiers of detail - like a road atlas with
-          state highways, regional roads, and back roads. The whole country is always on
-          the map; only the level of detail varies.
+          they do, we group sectors into three tiers of detail - like a national wiring map
+          where some regions are surveyed circuit by circuit and others are only metered at
+          the connection. Every sector is always on the map; only the level of detail varies.
         </p>
         <div className="mt-4 grid gap-4 md:grid-cols-3">
           {TIER_RIBBON.map((t) => (
@@ -369,7 +397,7 @@ export default function HowItWorksPage() {
         <header className="mb-3">
           <p className="eyebrow">The five policy scenarios</p>
           <h2 className="mt-1 font-display text-2xl text-ink">
-            Different ways to spend the same roadworks budget
+            Different ways to spend the same electrification budget
           </h2>
           <p className="mt-2 max-w-3xl text-sm leading-relaxed text-steel">
             Every scenario uses the same budget envelope and the same time horizon. Only
@@ -389,6 +417,51 @@ export default function HowItWorksPage() {
         </div>
       </section>
 
+      <section id="why-now" className="mt-8 scroll-mt-24 surface-card p-6">
+        <p className="eyebrow">Why it matters now</p>
+        <h2 className="mt-1 font-display text-2xl text-ink">
+          A real productivity bet, read through the sandbox
+        </h2>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+          A common policy claim is that AI will lift productivity - and sometimes that
+          promised dividend is banked in advance. In May 2026 the Government announced
+          plans to reduce the public-sector workforce by roughly 8,700 roles and merge
+          agencies, with AI and digital tools cited among the ways services would be
+          maintained with fewer people. Those figures are the Government&apos;s own
+          announced target, used here only as context - not a model output.
+        </p>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+          The sandbox does not judge whether that bet pays off. It makes the
+          preconditions visible. In our framing, the productivity gain (P) only arrives
+          as work actually runs on power (A), and adoption only grows where a sector is
+          wired up (K). Evidence on the public sector points to a low starting K -
+          capability gaps, a risk-averse culture, and pilots that have not yet shown a
+          clear dividend.
+        </p>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+          Read that way, trimming headcount on the strength of a future AI dividend is a
+          wager that wiring (K) and adoption (A) rise fast enough to deliver the output
+          (P) before the workforce strain (L) bites. The sandbox lets you see what would
+          have to be true; it does not promise the outcome either way.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+          <Link
+            href="/evidence"
+            className="font-medium text-ink underline underline-offset-4"
+          >
+            See the public-sector signal in the evidence index
+          </Link>
+          <a
+            href={RNZ_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-steel underline underline-offset-4 hover:text-ink"
+          >
+            Source: RNZ, 24 May 2026
+          </a>
+        </div>
+      </section>
+
       <section id="limits" className="mt-8 scroll-mt-24 rounded-2xl border border-datum/25 bg-datum/10 p-6">
         <p className="eyebrow">What this cannot tell you</p>
         <h2 className="mt-1 font-display text-2xl text-ink">
@@ -405,6 +478,8 @@ export default function HowItWorksPage() {
           See the <Link href="/methodology" className="font-medium text-ink underline underline-offset-4">methodology brief</Link> for the longer technical version.
         </p>
       </section>
+        </div>
+      </div>
 
       <section className="mt-8 surface-card p-6">
         <p className="eyebrow">Next step</p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,8 +30,16 @@ export default function RootLayout({
   return (
     <html lang="en-NZ">
       <body className={`${bodySans.variable} ${displaySerif.variable}`}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:border focus:border-ink/20 focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-ink focus:shadow-sm"
+        >
+          Skip to main content
+        </a>
         <SiteHeader />
-        {children}
+        <div id="main-content" tabIndex={-1} className="outline-none">
+          {children}
+        </div>
         <SiteFooter />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
 
+import SystemDiagram from "@/components/explainer/system-diagram";
+
+const RNZ_URL =
+  "https://www.rnz.co.nz/news/political/595655/nearly-9000-public-sector-jobs-to-go-government-agencies-to-merge-nicola-willis-announces";
+
 const pillars = [
   {
     title: "Comparative, Not Predictive",
@@ -38,7 +43,10 @@ export default function HomePage() {
           </h1>
 
           <p className="max-w-3xl text-lg leading-relaxed text-steel">
-            Compare policy options in a transparent way across New Zealand sectors, with assumptions and caveats visible.
+            Different surveys put New Zealand&apos;s AI use anywhere from 32% to 87%. This
+            sandbox is a transparent way to compare policy options under that uncertainty -
+            same assumptions, same budget, same economy-wide scope - so the tradeoffs stay
+            visible rather than hidden.
           </p>
 
           <div className="grid gap-3 sm:flex sm:items-center">
@@ -109,6 +117,19 @@ export default function HomePage() {
               <span className="font-semibold">What it does not do:</span> provide exact forecasts, exact GDP paths, or definitive rankings.
             </li>
           </ul>
+
+          <SystemDiagram variant="compact" className="mt-6" />
+          <p className="mt-3 text-sm leading-relaxed text-steel">
+            The short version: a shared national capacity underpins every sector; a
+            sector has to be ready before AI use grows, and productivity follows use.{" "}
+            <Link
+              href="/how-it-works"
+              className="font-medium text-ink underline underline-offset-4"
+            >
+              See the full picture in plain English
+            </Link>
+            .
+          </p>
         </article>
       </section>
 
@@ -124,7 +145,7 @@ export default function HomePage() {
         ))}
       </section>
 
-      <section className="mx-auto w-full max-w-6xl px-6 pb-16 md:px-10">
+      <section className="mx-auto w-full max-w-6xl px-6 pb-8 md:px-10">
         <div className="rounded-2xl border border-datum/30 bg-datum/10 p-6 md:p-8">
           <p className="eyebrow !text-datum">Primary comparison dimensions</p>
           <ul className="mt-4 grid gap-3 md:grid-cols-2">
@@ -140,6 +161,48 @@ export default function HomePage() {
           <p className="mt-5 text-sm leading-relaxed text-steel">
             Every head-to-head comparison should maintain like-for-like assumptions for budget envelope, horizon, and sector coverage.
           </p>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-16 md:px-10">
+        <div className="rounded-2xl border border-ink/15 bg-white/70 p-6 md:p-8">
+          <p className="eyebrow">In the news</p>
+          <h2 className="mt-2 font-display text-2xl text-ink">
+            When productivity is banked before it arrives
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-steel">
+            Policy debates increasingly treat AI as a productivity lever - sometimes
+            counting the dividend in advance. For example, the Government&apos;s May 2026
+            plan to reduce the public-sector workforce by roughly 8,700 roles and merge
+            agencies leaned on AI and digital tools to maintain services with fewer
+            people. The sandbox does not forecast whether such bets pay off; it makes the
+            preconditions visible - productivity rises only as adoption matures, and
+            adoption grows only where a sector is ready. Those figures are the
+            Government&apos;s own announced target, used here as context, not a model
+            output.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <Link
+              href="/how-it-works#why-now"
+              className="font-medium text-ink underline underline-offset-4"
+            >
+              See how the sandbox reads this
+            </Link>
+            <Link
+              href="/evidence"
+              className="font-medium text-steel underline underline-offset-4 hover:text-ink"
+            >
+              Public-sector signal in the evidence index
+            </Link>
+            <a
+              href={RNZ_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-steel underline underline-offset-4 hover:text-ink"
+            >
+              Source: RNZ, 24 May 2026
+            </a>
+          </div>
         </div>
       </section>
     </main>

--- a/components/baseline/baseline-sector-chart.tsx
+++ b/components/baseline/baseline-sector-chart.tsx
@@ -1,20 +1,9 @@
 import ChartIntro from "@/components/charts/chart-intro";
 import type { BaselineSectorPoint } from "@/lib/model/baseline";
+import { GRIDLINE_COLOUR, TIER_COLOURS, TIER_LABELS } from "@/lib/ui/theme";
 
 type Props = {
   sectors: ReadonlyArray<BaselineSectorPoint>;
-};
-
-const TIER_COLOUR: Record<1 | 2 | 3, string> = {
-  1: "#0f172a",
-  2: "#0891b2",
-  3: "#94a3b8",
-};
-
-const TIER_LABEL: Record<1 | 2 | 3, string> = {
-  1: "Tier 1 — full dynamics",
-  2: "Tier 2 — simplified",
-  3: "Tier 3 — residual",
 };
 
 const WIDTH = 640;
@@ -55,7 +44,7 @@ export default function BaselineSectorChart({ sectors }: Props) {
                 x2={xScale(v)}
                 y1={0}
                 y2={innerH}
-                stroke="#e2e8f0"
+                stroke={GRIDLINE_COLOUR}
               />
               <text
                 x={xScale(v)}
@@ -78,7 +67,7 @@ export default function BaselineSectorChart({ sectors }: Props) {
                   y={(ROW_HEIGHT - barH) / 2}
                   width={4}
                   height={barH}
-                  fill={TIER_COLOUR[s.tier]}
+                  fill={TIER_COLOURS[s.tier]}
                 />
                 <text
                   x={-MARGIN.left + 14}
@@ -94,7 +83,7 @@ export default function BaselineSectorChart({ sectors }: Props) {
                   y={(ROW_HEIGHT - barH) / 2}
                   width={xScale(s.A0)}
                   height={barH}
-                  fill={TIER_COLOUR[s.tier]}
+                  fill={TIER_COLOURS[s.tier]}
                   opacity={0.85}
                 >
                   <title>{`${s.name}: A₀ = ${s.A0.toFixed(2)} · evidence: ${s.evidenceClass} · confidence: ${s.confidence}${s.notes ? ` · ${s.notes}` : ""}`}</title>
@@ -117,9 +106,9 @@ export default function BaselineSectorChart({ sectors }: Props) {
         <g transform={`translate(${MARGIN.left},${height - 10})`}>
           {([1, 2, 3] as const).map((t, idx) => (
             <g key={t} transform={`translate(${idx * 170},0)`}>
-              <rect width={10} height={10} y={-9} fill={TIER_COLOUR[t]} />
+              <rect width={10} height={10} y={-9} fill={TIER_COLOURS[t]} />
               <text x={14} y={0} className="fill-steel" fontSize={10}>
-                {TIER_LABEL[t]}
+                {TIER_LABELS[t]}
               </text>
             </g>
           ))}

--- a/components/compare/policy-lab-panel.tsx
+++ b/components/compare/policy-lab-panel.tsx
@@ -45,6 +45,7 @@ export type ScenarioChip = {
 
 type Props = {
   scenarios: ReadonlyArray<ScenarioChip>;
+  referenceName?: string;
   staged: PolicyLabConfig;
   applied: PolicyLabConfig;
   onChange: (next: PolicyLabConfig) => void;
@@ -74,6 +75,7 @@ function configsEqual(a: PolicyLabConfig, b: PolicyLabConfig): boolean {
 
 export default function PolicyLabPanel({
   scenarios,
+  referenceName = "Status quo",
   staged,
   applied,
   onChange,
@@ -117,6 +119,15 @@ export default function PolicyLabPanel({
         <legend className="text-xs font-semibold uppercase tracking-[0.16em] text-steel">
           1. Scenarios to compare
         </legend>
+        <div className="mt-2 flex items-center gap-2 rounded-xl border border-dashed border-ink/30 bg-canvas/50 px-3 py-2">
+          <span className="rounded-full bg-ink/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-steel">
+            Reference
+          </span>
+          <span className="text-sm text-ink">
+            <span className="font-medium">{referenceName}</span> - always on. Every
+            scenario is measured against this.
+          </span>
+        </div>
         <div className="mt-2 grid gap-2 sm:grid-cols-2">
           {scenarios.map((s) => {
             const isOn = staged.selectedScenarioIds.includes(s.id);
@@ -124,6 +135,7 @@ export default function PolicyLabPanel({
               <button
                 key={s.id}
                 type="button"
+                aria-pressed={isOn}
                 onClick={() => toggleScenario(s.id)}
                 className={`rounded-xl border px-3 py-2 text-left text-sm transition ${
                   isOn
@@ -271,6 +283,12 @@ export default function PolicyLabPanel({
 
       {/* Action bar */}
       <div className="mt-6 flex flex-wrap items-center justify-end gap-2 border-t border-ink/10 pt-4">
+        <a
+          href="#results"
+          className="mr-auto text-sm font-medium text-ink underline underline-offset-4"
+        >
+          View results &darr;
+        </a>
         <button
           type="button"
           onClick={onShare}
@@ -292,7 +310,7 @@ export default function PolicyLabPanel({
           className="rounded-xl bg-ink px-4 py-2 text-sm font-medium text-canvas hover:bg-ink/90 disabled:cursor-not-allowed disabled:opacity-50"
           disabled={!isDirty}
         >
-          {isDirty ? "Run simulation" : "Run simulation (no changes)"}
+          {isDirty ? "Run simulation" : "Results up to date"}
         </button>
       </div>
     </section>

--- a/components/compare/sector-adoption-chart.tsx
+++ b/components/compare/sector-adoption-chart.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import ChartIntro from "@/components/charts/chart-intro";
+import ChartLegend from "@/components/ui/chart-legend";
 import type { ScenarioOutcomes } from "@/lib/model/compare";
+import {
+  AXIS_COLOUR,
+  GRIDLINE_COLOUR,
+  MUTED_COLOUR,
+  SCENARIO_NON_REFERENCE,
+  TIER_COLOURS,
+} from "@/lib/ui/theme";
 
 type Props = {
   scenarios: ReadonlyArray<ScenarioOutcomes>;
   horizonYears: number;
-};
-
-const TIER_COLOUR: Record<1 | 2 | 3, string> = {
-  1: "#0f172a",
-  2: "#0891b2",
-  3: "#94a3b8",
 };
 
 const WIDTH = 560;
@@ -43,7 +45,9 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
       <svg
         viewBox={`0 0 ${WIDTH} ${height}`}
         role="img"
-        aria-label="Adoption per sector at the horizon"
+        aria-label={`Adoption per sector at year ${horizonYears} for ${scenarios
+          .map((s) => s.scenarioName)
+          .join(", ")}`}
         className="block h-auto w-full"
       >
         <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
@@ -55,7 +59,7 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
                 x2={xScale(v)}
                 y1={0}
                 y2={innerH}
-                stroke="#e2e8f0"
+                stroke={GRIDLINE_COLOUR}
                 strokeWidth={1}
               />
               <text
@@ -80,7 +84,7 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
                   y={(ROW_HEIGHT - barH) / 2}
                   width={4}
                   height={barH}
-                  fill={TIER_COLOUR[sector.tier]}
+                  fill={TIER_COLOURS[sector.tier]}
                 />
                 {/* sector label */}
                 <text
@@ -98,8 +102,10 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
                   const value = s.series.adoptionAtHorizon[rowIdx].A;
                   const colour =
                     sIdx === 0 || s.isReference
-                      ? "#94a3b8"
-                      : ["#0891b2", "#ea580c", "#7c3aed", "#16a34a"][(sIdx - 1) % 4];
+                      ? MUTED_COLOUR
+                      : SCENARIO_NON_REFERENCE[
+                          (sIdx - 1) % SCENARIO_NON_REFERENCE.length
+                        ];
                   return (
                     <rect
                       key={`${s.scenarioId}-${sector.sectorId}`}
@@ -119,30 +125,17 @@ export default function SectorAdoptionChart({ scenarios, horizonYears }: Props) 
           })}
 
           {/* baseline axis */}
-          <line x1={0} x2={0} y1={0} y2={innerH} stroke="#0f172a" strokeWidth={1.2} />
+          <line x1={0} x2={0} y1={0} y2={innerH} stroke={AXIS_COLOUR} strokeWidth={1.2} />
         </g>
       </svg>
 
-      <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-steel">
-        <li className="flex items-center gap-1.5">
-          <svg aria-hidden width={8} height={8} className="inline-block">
-            <rect width={8} height={8} rx={1.5} fill={TIER_COLOUR[1]} />
-          </svg>
-          Tier 1 (full state)
-        </li>
-        <li className="flex items-center gap-1.5">
-          <svg aria-hidden width={8} height={8} className="inline-block">
-            <rect width={8} height={8} rx={1.5} fill={TIER_COLOUR[2]} />
-          </svg>
-          Tier 2 (reduced)
-        </li>
-        <li className="flex items-center gap-1.5">
-          <svg aria-hidden width={8} height={8} className="inline-block">
-            <rect width={8} height={8} rx={1.5} fill={TIER_COLOUR[3]} />
-          </svg>
-          Tier 3 (adoption only)
-        </li>
-      </ul>
+      <ChartLegend
+        items={[
+          { id: "t1", colour: TIER_COLOURS[1], label: "Tier 1 (full state)" },
+          { id: "t2", colour: TIER_COLOURS[2], label: "Tier 2 (reduced)" },
+          { id: "t3", colour: TIER_COLOURS[3], label: "Tier 3 (adoption only)" },
+        ]}
+      />
     </figure>
   );
 }

--- a/components/compare/trajectory-chart.tsx
+++ b/components/compare/trajectory-chart.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import ChartIntro from "@/components/charts/chart-intro";
+import ChartLegend from "@/components/ui/chart-legend";
 import type { ScenarioOutcomes, SeriesPoint } from "@/lib/model/compare";
+import {
+  AXIS_COLOUR,
+  GRIDLINE_COLOUR,
+  SCENARIO_PALETTE,
+} from "@/lib/ui/theme";
 
 type SeriesSelector = "pBar" | "E";
 
@@ -14,14 +20,6 @@ type Props = {
   symbol?: string;
   explainerHref?: string;
 };
-
-const PALETTE = [
-  "#0f172a", // ink
-  "#0891b2", // datum
-  "#ea580c", // accent
-  "#7c3aed",
-  "#16a34a",
-];
 
 const WIDTH = 560;
 const HEIGHT = 240;
@@ -77,7 +75,9 @@ export default function TrajectoryChart({
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         role="img"
-        aria-label={`${title} - line chart across selected scenarios`}
+        aria-label={`${title} - line chart across ${scenarios
+          .map((s) => s.scenarioName)
+          .join(", ")}`}
         className="block h-auto w-full"
       >
         <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
@@ -89,7 +89,7 @@ export default function TrajectoryChart({
                 x2={innerW}
                 y1={yScale(v)}
                 y2={yScale(v)}
-                stroke="#e2e8f0"
+                stroke={GRIDLINE_COLOUR}
                 strokeWidth={1}
               />
               <text
@@ -127,8 +127,8 @@ export default function TrajectoryChart({
             </g>
           ))}
           {/* axes */}
-          <line x1={0} x2={innerW} y1={innerH} y2={innerH} stroke="#0f172a" strokeWidth={1.2} />
-          <line x1={0} x2={0} y1={0} y2={innerH} stroke="#0f172a" strokeWidth={1.2} />
+          <line x1={0} x2={innerW} y1={innerH} y2={innerH} stroke={AXIS_COLOUR} strokeWidth={1.2} />
+          <line x1={0} x2={0} y1={0} y2={innerH} stroke={AXIS_COLOUR} strokeWidth={1.2} />
           {/* axis labels */}
           <text
             x={innerW / 2}
@@ -151,7 +151,7 @@ export default function TrajectoryChart({
           {/* series */}
           {scenarios.map((s, i) => {
             const pts = pickPoints(s, series);
-            const colour = PALETTE[i % PALETTE.length];
+            const colour = SCENARIO_PALETTE[i % SCENARIO_PALETTE.length];
             return (
               <g key={s.scenarioId}>
                 <path
@@ -176,30 +176,15 @@ export default function TrajectoryChart({
         </g>
       </svg>
 
-      <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-steel">
-        {scenarios.map((s, i) => {
-          const colour = PALETTE[i % PALETTE.length];
-          return (
-            <li key={s.scenarioId} className="flex items-center gap-2">
-              <svg aria-hidden width={20} height={6} className="inline-block">
-                <line
-                  x1={0}
-                  x2={20}
-                  y1={3}
-                  y2={3}
-                  stroke={colour}
-                  strokeWidth={2}
-                  strokeDasharray={s.isReference ? "4 3" : undefined}
-                />
-              </svg>
-              <span>
-                {s.scenarioName}
-                {s.isReference ? " (reference)" : ""}
-              </span>
-            </li>
-          );
-        })}
-      </ul>
+      <ChartLegend
+        items={scenarios.map((s, i) => ({
+          id: s.scenarioId,
+          colour: SCENARIO_PALETTE[i % SCENARIO_PALETTE.length],
+          shape: "line",
+          dashed: s.isReference,
+          label: `${s.scenarioName}${s.isReference ? " (reference)" : ""}`,
+        }))}
+      />
     </figure>
   );
 }

--- a/components/explainer/on-this-page.tsx
+++ b/components/explainer/on-this-page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type OnThisPageItem = {
+  /** The id of the target section element (without the leading #). */
+  id: string;
+  /** Short label shown in the navigation. */
+  label: string;
+};
+
+type OnThisPageProps = {
+  items: OnThisPageItem[];
+};
+
+/**
+ * A jump-navigation rail for long explainer pages.
+ *
+ * On large screens it renders as a sticky sidebar; on smaller screens it
+ * collapses to a horizontally scrollable chip row at the top of the content.
+ * A scroll-spy (IntersectionObserver) highlights the section currently in view.
+ * All targets are existing section ids on the page, so it degrades gracefully
+ * if JavaScript is disabled - the links still jump to the right anchor.
+ */
+export default function OnThisPage({ items }: OnThisPageProps) {
+  const [activeId, setActiveId] = useState<string | null>(items[0]?.id ?? null);
+
+  useEffect(() => {
+    const sections = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-96px 0px -55% 0px", threshold: 0 },
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, [items]);
+
+  return (
+    <nav aria-label="On this page" className="lg:sticky lg:top-24">
+      <p className="eyebrow hidden lg:block">On this page</p>
+      <ul className="mt-2 flex gap-2 overflow-x-auto pb-2 lg:flex-col lg:gap-1 lg:overflow-visible lg:pb-0">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <li key={item.id} className="shrink-0 lg:shrink">
+              <a
+                href={`#${item.id}`}
+                aria-current={isActive ? "true" : undefined}
+                className={
+                  "block whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition lg:rounded-md lg:border-l-2 lg:border-y-0 lg:border-r-0 lg:px-3 lg:py-1.5 lg:text-sm " +
+                  (isActive
+                    ? "border-ink bg-ink/5 text-ink lg:border-l-accent"
+                    : "border-ink/15 bg-white/60 text-steel hover:text-ink lg:border-l-transparent lg:bg-transparent")
+                }
+              >
+                {item.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/components/explainer/system-diagram.tsx
+++ b/components/explainer/system-diagram.tsx
@@ -1,0 +1,226 @@
+// Shared concept diagram for the explainer and home pages.
+//
+// Renders the electrification analogy the sandbox is built around: a shared
+// national grid (E) underpins every sector, policy spending either builds the
+// grid (supply) or wires up a sector (demand), and a wired sector runs work on
+// power (A) that yields output (P) while creating workforce strain (L).
+//
+// The SVG is decorative-with-meaning: it carries role="img" plus a full-sentence
+// aria-label, and the visible mapping list below doubles as the text alternative
+// and a no-detail-lost fallback. Colours reference the shared CSS tokens so the
+// diagram tracks the rest of the palette.
+
+type Variant = "full" | "compact";
+
+type Tone = "grid" | "sector" | "payoff" | "strain";
+
+const TONE_STYLE: Record<Tone, { fill: string; fillOpacity: number; stroke: string }> = {
+  grid: { fill: "var(--datum)", fillOpacity: 0.1, stroke: "var(--datum)" },
+  sector: { fill: "#ffffff", fillOpacity: 0.92, stroke: "var(--ink)" },
+  payoff: { fill: "var(--accent)", fillOpacity: 0.1, stroke: "var(--accent)" },
+  strain: { fill: "var(--steel)", fillOpacity: 0.1, stroke: "var(--steel)" },
+};
+
+type NodeProps = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  symbol: string;
+  title: string;
+  subtitle?: string;
+  tone: Tone;
+};
+
+function Node({ x, y, w, h, symbol, title, subtitle, tone }: NodeProps) {
+  const style = TONE_STYLE[tone];
+  const cx = x + 26;
+  const cy = y + 26;
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={12}
+        fill={style.fill}
+        fillOpacity={style.fillOpacity}
+        stroke={style.stroke}
+        strokeWidth={1.5}
+      />
+      <circle cx={cx} cy={cy} r={15} fill={style.stroke} />
+      <text
+        x={cx}
+        y={cy + 5}
+        textAnchor="middle"
+        fontSize={16}
+        fontWeight={700}
+        fill="#f7f3ea"
+      >
+        {symbol}
+      </text>
+      <text x={x + 52} y={y + 24} fontSize={14} fontWeight={600} fill="var(--ink)">
+        {title}
+      </text>
+      {subtitle ? (
+        <text x={x + 18} y={y + 50} fontSize={11.5} fill="var(--steel)">
+          {subtitle}
+        </text>
+      ) : null}
+    </g>
+  );
+}
+
+const MAPPING: { symbol: string; label: string; gloss: string }[] = [
+  { symbol: "E", label: "National grid", gloss: "Shared skills, infrastructure, trust, and rules every sector draws on." },
+  { symbol: "K", label: "Sector wired up", gloss: "How ready a sector is to actually plug AI into its work." },
+  { symbol: "A", label: "Work on power", gloss: "How much AI is in genuine operational use." },
+  { symbol: "P", label: "Extra output", gloss: "The productivity gain actually delivered as use matures." },
+  { symbol: "L", label: "Workforce strain", gloss: "Pressure on workers as roles are reorganised." },
+];
+
+function FullDiagram() {
+  return (
+    <svg
+      viewBox="0 0 820 440"
+      className="h-auto w-full"
+      role="img"
+      aria-label="Diagram of the electrification analogy. A shared national grid, labelled E, underpins every sector. A policy budget splits into supply spending that builds the grid and demand spending that wires up a sector, labelled K. Once a sector is wired, work runs on power, labelled A, which yields extra output, labelled P, and creates workforce reorganisation strain, labelled L."
+    >
+      <title>How AI policy moves through the economy</title>
+      <desc>
+        Policy budget feeds the national grid (supply) and individual sectors (demand);
+        a wired sector turns power into output while creating workforce strain.
+      </desc>
+      <defs>
+        <marker id="arrow-ink" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--ink)" />
+        </marker>
+        <marker id="arrow-accent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--accent)" />
+        </marker>
+        <marker id="arrow-datum" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--datum)" />
+        </marker>
+      </defs>
+
+      {/* Policy budget */}
+      <Node x={285} y={18} w={250} h={50} symbol="$" title="Policy budget" subtitle="Same envelope, same horizon" tone="payoff" />
+
+      {/* Sector pipeline */}
+      <Node x={40} y={168} w={210} h={92} symbol="K" title="Sector wired up" subtitle="Skills, data, processes ready" tone="sector" />
+      <Node x={305} y={168} w={210} h={92} symbol="A" title="Work on power" subtitle="AI in genuine use" tone="sector" />
+      <Node x={570} y={168} w={210} h={92} symbol="P" title="Extra output" subtitle="Productivity gain delivered" tone="payoff" />
+
+      {/* Labour strain */}
+      <Node x={305} y={296} w={210} h={56} symbol="L" title="Workforce strain" tone="strain" />
+
+      {/* National grid foundation */}
+      <rect x={40} y={372} width={740} height={56} rx={12} fill="var(--datum)" fillOpacity={0.1} stroke="var(--datum)" strokeWidth={1.5} />
+      <circle cx={66} cy={400} r={15} fill="var(--datum)" />
+      <text x={66} y={405} textAnchor="middle" fontSize={16} fontWeight={700} fill="#f7f3ea">E</text>
+      <text x={92} y={396} fontSize={14} fontWeight={600} fill="var(--ink)">National grid - shared by every sector</text>
+      <text x={92} y={416} fontSize={11.5} fill="var(--steel)">Skills, infrastructure, trust, and the standards and rules for AI</text>
+
+      {/* Policy -> demand -> K */}
+      <path d="M360,68 C 300,110 220,128 150,166" fill="none" stroke="var(--accent)" strokeWidth={1.75} markerEnd="url(#arrow-accent)" />
+      <text x={205} y={120} fontSize={11.5} fontWeight={600} fill="var(--accent)">demand</text>
+
+      {/* Policy -> supply -> grid (routed down the right corridor) */}
+      <path d="M470,66 C 700,90 800,210 790,360" fill="none" stroke="var(--accent)" strokeWidth={1.75} markerEnd="url(#arrow-accent)" />
+      <text x={690} y={150} fontSize={11.5} fontWeight={600} fill="var(--accent)">supply</text>
+
+      {/* Grid -> K (the grid underpins capability) */}
+      <path d="M130,372 L132,264" fill="none" stroke="var(--datum)" strokeWidth={1.75} markerEnd="url(#arrow-datum)" />
+
+      {/* K -> A */}
+      <path d="M250,214 L301,214" fill="none" stroke="var(--ink)" strokeWidth={1.75} markerEnd="url(#arrow-ink)" />
+      <text x={258} y={205} fontSize={11} fill="var(--steel)">opens</text>
+
+      {/* A -> P */}
+      <path d="M515,214 L566,214" fill="none" stroke="var(--ink)" strokeWidth={1.75} markerEnd="url(#arrow-ink)" />
+      <text x={523} y={205} fontSize={11} fill="var(--steel)">yields</text>
+
+      {/* A -> L */}
+      <path d="M410,260 L410,292" fill="none" stroke="var(--steel)" strokeWidth={1.75} markerEnd="url(#arrow-ink)" />
+      <text x={418} y={282} fontSize={11} fill="var(--steel)">strains</text>
+    </svg>
+  );
+}
+
+function CompactDiagram() {
+  return (
+    <svg
+      viewBox="0 0 760 220"
+      className="h-auto w-full"
+      role="img"
+      aria-label="Diagram of the electrification analogy. A shared national grid, labelled E, underpins each sector. A wired-up sector, labelled K, lets work run on power, labelled A, which yields extra output, labelled P."
+    >
+      <title>How AI adoption turns into productivity</title>
+      <desc>A shared national grid underpins each sector; a wired sector turns power into output.</desc>
+      <defs>
+        <marker id="arrow-ink-c" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--ink)" />
+        </marker>
+        <marker id="arrow-datum-c" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--datum)" />
+        </marker>
+      </defs>
+
+      <Node x={30} y={24} w={210} h={84} symbol="K" title="Sector wired up" subtitle="Ready to use AI" tone="sector" />
+      <Node x={275} y={24} w={210} h={84} symbol="A" title="Work on power" subtitle="AI in genuine use" tone="sector" />
+      <Node x={520} y={24} w={210} h={84} symbol="P" title="Extra output" subtitle="Productivity gain" tone="payoff" />
+
+      <rect x={30} y={150} width={700} height={48} rx={12} fill="var(--datum)" fillOpacity={0.1} stroke="var(--datum)" strokeWidth={1.5} />
+      <circle cx={54} cy={174} r={13} fill="var(--datum)" />
+      <text x={54} y={179} textAnchor="middle" fontSize={14} fontWeight={700} fill="#f7f3ea">E</text>
+      <text x={78} y={179} fontSize={13} fontWeight={600} fill="var(--ink)">National grid - shared skills, infrastructure, trust, and rules</text>
+
+      <path d="M240,66 L271,66" fill="none" stroke="var(--ink)" strokeWidth={1.75} markerEnd="url(#arrow-ink-c)" />
+      <text x={246} y={57} fontSize={11} fill="var(--steel)">opens</text>
+      <path d="M485,66 L516,66" fill="none" stroke="var(--ink)" strokeWidth={1.75} markerEnd="url(#arrow-ink-c)" />
+      <text x={491} y={57} fontSize={11} fill="var(--steel)">yields</text>
+      <path d="M120,150 L122,110" fill="none" stroke="var(--datum)" strokeWidth={1.75} markerEnd="url(#arrow-datum-c)" />
+    </svg>
+  );
+}
+
+type SystemDiagramProps = {
+  variant?: Variant;
+  className?: string;
+};
+
+/**
+ * The shared electrification concept diagram.
+ *
+ * - `full` shows the whole system: policy budget (supply and demand), the grid
+ *   foundation, the K to A to P pipeline, and the L strain branch.
+ * - `compact` shows just the grid foundation under the K to A to P pipeline,
+ *   for use on the home page.
+ */
+export default function SystemDiagram({ variant = "full", className }: SystemDiagramProps) {
+  const showMapping = variant === "full";
+  return (
+    <figure className={className}>
+      <div className="rounded-2xl border border-ink/15 bg-white/70 p-4 md:p-6">
+        {variant === "full" ? <FullDiagram /> : <CompactDiagram />}
+      </div>
+      {showMapping ? (
+        <figcaption className="mt-4">
+          <p className="eyebrow">What each part means</p>
+          <dl className="mt-2 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+            {MAPPING.map((m) => (
+              <div key={m.symbol} className="flex gap-2 text-sm leading-relaxed">
+                <dt className="shrink-0 font-semibold text-ink">
+                  {m.symbol} - {m.label}:
+                </dt>
+                <dd className="text-steel">{m.gloss}</dd>
+              </div>
+            ))}
+          </dl>
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/components/ui/chart-legend.tsx
+++ b/components/ui/chart-legend.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+export type ChartLegendItem = {
+  /** Stable key for the item. */
+  id: string;
+  colour: string;
+  label: ReactNode;
+  /** "swatch" draws a filled square; "line" draws a horizontal rule. */
+  shape?: "swatch" | "line";
+  /** Render the line/swatch with the reference dash pattern. */
+  dashed?: boolean;
+};
+
+type Props = {
+  items: ReadonlyArray<ChartLegendItem>;
+};
+
+/** Shared legend used by the baseline and compare charts. */
+export default function ChartLegend({ items }: Props) {
+  return (
+    <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-steel">
+      {items.map((item) => (
+        <li key={item.id} className="flex items-center gap-2">
+          {item.shape === "line" ? (
+            <svg aria-hidden width={20} height={6} className="inline-block">
+              <line
+                x1={0}
+                x2={20}
+                y1={3}
+                y2={3}
+                stroke={item.colour}
+                strokeWidth={2}
+                strokeDasharray={item.dashed ? "4 3" : undefined}
+              />
+            </svg>
+          ) : (
+            <svg aria-hidden width={8} height={8} className="inline-block">
+              <rect width={8} height={8} rx={1.5} fill={item.colour} />
+            </svg>
+          )}
+          <span>{item.label}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/lib/model/baseline.ts
+++ b/lib/model/baseline.ts
@@ -27,16 +27,24 @@ function lookupA0AndEvidence(sector: (typeof CONTENT.sectors)[number]): {
   confidence: Confidence;
   notes?: string;
 } {
-  if (sector.tier === 1) {
-    const row = CONTENT.parameters.tier1[sector.id];
-    return { A0: row.A0, evidenceClass: row.evidenceClass, confidence: row.confidence, notes: row.notes };
+  const table =
+    sector.tier === 1
+      ? CONTENT.parameters.tier1
+      : sector.tier === 2
+        ? CONTENT.parameters.tier2
+        : CONTENT.parameters.tier3;
+  const row = table[sector.id];
+  if (!row) {
+    throw new Error(
+      `Missing tier${sector.tier} parameters for sector ${sector.id}`,
+    );
   }
-  if (sector.tier === 2) {
-    const row = CONTENT.parameters.tier2[sector.id];
-    return { A0: row.A0, evidenceClass: row.evidenceClass, confidence: row.confidence, notes: row.notes };
-  }
-  const row = CONTENT.parameters.tier3[sector.id];
-  return { A0: row.A0, evidenceClass: row.evidenceClass, confidence: row.confidence, notes: row.notes };
+  return {
+    A0: row.A0,
+    evidenceClass: row.evidenceClass,
+    confidence: row.confidence,
+    notes: row.notes,
+  };
 }
 
 export function buildBaselineSnapshot(): BaselineSnapshot {

--- a/lib/model/compare.ts
+++ b/lib/model/compare.ts
@@ -1,6 +1,6 @@
 // Compare module: run multiple scenarios + status-quo, emit qualitative deltas.
 
-import { CONTENT } from "./content";
+import { CONTENT, sectorById } from "./content";
 import { runScenario, type RunOverrides, type Trajectory } from "./engine";
 import type { PolicyScenario } from "./schemas";
 
@@ -102,17 +102,15 @@ export const OUTCOME_DIMENSIONS = [
 function aggregatePBar(traj: Trajectory, snapshotIdx: number): number {
   let total = 0;
   CONTENT.tier1Ids.forEach((id, i) => {
-    const w = CONTENT.sectors.find((s) => s.id === id)!.gdpWeight;
-    total += w * traj.tier1[i].P[snapshotIdx];
+    total += sectorById(id).gdpWeight * traj.tier1[i].P[snapshotIdx];
   });
   CONTENT.tier2Ids.forEach((id, i) => {
-    const w = CONTENT.sectors.find((s) => s.id === id)!.gdpWeight;
-    total += w * traj.tier2[i].P[snapshotIdx];
+    total += sectorById(id).gdpWeight * traj.tier2[i].P[snapshotIdx];
   });
   CONTENT.tier3Ids.forEach((id, i) => {
-    const w = CONTENT.sectors.find((s) => s.id === id)!.gdpWeight;
+    // Tier 3 has no explicit P state; psi * A is its productivity proxy.
     const psi = CONTENT.parameters.tier3[id].psi;
-    total += w * psi * traj.tier3[i].A[snapshotIdx];
+    total += sectorById(id).gdpWeight * psi * traj.tier3[i].A[snapshotIdx];
   });
   return total;
 }
@@ -133,12 +131,8 @@ function adoptionSpread(traj: Trajectory, snapshotIdx: number): number {
 function labourPressureIntegral(traj: Trajectory): number {
   const n = traj.times.length;
   // Pre-compute weights and Tier 2 phi.
-  const weightsT1 = CONTENT.tier1Ids.map(
-    (id) => CONTENT.sectors.find((s) => s.id === id)!.gdpWeight,
-  );
-  const weightsT2 = CONTENT.tier2Ids.map(
-    (id) => CONTENT.sectors.find((s) => s.id === id)!.gdpWeight,
-  );
+  const weightsT1 = CONTENT.tier1Ids.map((id) => sectorById(id).gdpWeight);
+  const weightsT2 = CONTENT.tier2Ids.map((id) => sectorById(id).gdpWeight);
   const phiT2 = CONTENT.tier2Ids.map((id) => CONTENT.parameters.tier2[id].phi);
 
   const lAt = (idx: number): number => {
@@ -164,7 +158,7 @@ function labourPressureIntegral(traj: Trajectory): number {
 function buildAdoptionAtHorizon(traj: Trajectory): SectorAdoptionPoint[] {
   const lastIdx = traj.times.length - 1;
   const points: SectorAdoptionPoint[] = [];
-  const meta = (id: string) => CONTENT.sectors.find((s) => s.id === id)!;
+  const meta = (id: string) => sectorById(id);
   CONTENT.tier1Ids.forEach((id, i) => {
     const m = meta(id);
     points.push({
@@ -233,7 +227,6 @@ function buildDelta(
 function computeOutcomes(
   traj: Trajectory,
   reference: Trajectory | null,
-  horizonYears: number,
 ): OutcomeDelta[] {
   const lastIdx = traj.times.length - 1;
   const refIdx = reference ? reference.times.length - 1 : lastIdx;
@@ -242,8 +235,6 @@ function computeOutcomes(
   const refSpread = reference ? adoptionSpread(reference, refIdx) : adoptionSpread(traj, lastIdx);
   const refLabour = reference ? labourPressureIntegral(reference) : labourPressureIntegral(traj);
   const refE = reference ? reference.E[refIdx] : traj.E[lastIdx];
-
-  void horizonYears;
 
   return [
     buildDelta(OUTCOME_DIMENSIONS[0], refPbar, aggregatePBar(traj, lastIdx)),
@@ -299,10 +290,12 @@ export function runComparison(
   for (const s of scenarios)
     trajectories.set(s.id, runScenario(apply(s), horizonYears, overrides));
 
-  const reference = trajectories.get(referenceId)!;
+  const reference = trajectories.get(referenceId);
+  if (!reference) throw new Error("Reference trajectory missing after run");
 
   const scenarioOutcomes: ScenarioOutcomes[] = scenarios.map((s) => {
-    const traj = trajectories.get(s.id)!;
+    const traj = trajectories.get(s.id);
+    if (!traj) throw new Error(`Trajectory missing for scenario ${s.id}`);
     return {
       scenarioId: s.id,
       scenarioName: s.name,
@@ -310,7 +303,6 @@ export function runComparison(
       outcomes: computeOutcomes(
         traj,
         s.id === referenceId ? null : reference,
-        horizonYears,
       ),
       series: {
         pBar: traj.times.map((t, i) => ({ t, value: aggregatePBar(traj, i) })),

--- a/lib/model/content.ts
+++ b/lib/model/content.ts
@@ -55,6 +55,18 @@ for (const id of tier3Ids) {
 
 const scenarios: ReadonlyArray<PolicyScenario> = scenariosParsed.scenarios;
 
+/** O(1) sector lookup by id, shared across model modules. */
+export const SECTOR_BY_ID: ReadonlyMap<string, Sector> = new Map(
+  sectors.map((s) => [s.id, s]),
+);
+
+/** Resolve a sector by id or throw with a descriptive error. */
+export function sectorById(id: string): Sector {
+  const sector = SECTOR_BY_ID.get(id);
+  if (!sector) throw new Error(`Unknown sector id: ${id}`);
+  return sector;
+}
+
 export const CONTENT = Object.freeze({
   version,
   globals,

--- a/lib/model/engine.ts
+++ b/lib/model/engine.ts
@@ -65,6 +65,22 @@ function gainLoss(X: number, rho: number, gain: number, loss: number): number {
   return rho * ((1 - X) * gain - X * loss);
 }
 
+/** Resolve a tier parameter row or throw with a descriptive error. */
+function requireParams<T>(
+  table: Record<string, T | undefined>,
+  id: string,
+  tier: 1 | 2 | 3,
+): T {
+  const row = table[id];
+  if (!row) throw new Error(`Missing tier${tier} parameters for sector ${id}`);
+  return row;
+}
+
+/** Exhaustiveness guard for discriminated unions. */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled scenario archetype: ${String(value)}`);
+}
+
 /**
  * Resolve per-sector policy support G_s and national investment G_E at time t
  * for a given scenario.
@@ -100,7 +116,12 @@ function buildLevers(scenario: PolicyScenario, overrides?: RunOverrides) {
 
   const Delta = scenario.deltaIntensity;
   const D = overrides?.leverDurationYears ?? scenario.leverDurationYears;
-  const active = (t: number) => t <= D + 1e-9;
+  // RK4 stage times are integer multiples of DT/2 (0.05 yr) and D is an
+  // integer, so any tolerance between float noise and one half-step gives
+  // identical results. 1e-6 removes accumulation noise at the boundary
+  // without ever flipping a stage's active state.
+  const ACTIVE_EPS = 1e-6;
+  const active = (t: number) => t <= D + ACTIVE_EPS;
 
   return {
     Gs(sectorId: string, t: number): number {
@@ -116,6 +137,8 @@ function buildLevers(scenario: PolicyScenario, overrides?: RunOverrides) {
           return 0;
         case "mixed":
           return split * Delta * (demandWeight.get(sectorId) ?? 0);
+        default:
+          return assertNever(scenario.archetype);
       }
     },
     GE(t: number): number {
@@ -125,8 +148,12 @@ function buildLevers(scenario: PolicyScenario, overrides?: RunOverrides) {
           return GEbase + Delta;
         case "mixed":
           return GEbase + (1 - split) * Delta;
-        default:
+        case "baseline":
+        case "aggregate":
+        case "targeted-demand":
           return GEbase;
+        default:
+          return assertNever(scenario.archetype);
       }
     },
   };
@@ -224,7 +251,7 @@ function derivatives(
 
   // Tier 1
   tier1Ids.forEach((id, i) => {
-    const p = parameters.tier1[id] as Tier1ParamRow;
+    const p = requireParams<Tier1ParamRow>(parameters.tier1, id, 1);
     const K = s.tier1[i * 4 + 0];
     const A = s.tier1[i * 4 + 1];
     const P = s.tier1[i * 4 + 2];
@@ -253,7 +280,7 @@ function derivatives(
 
   // Tier 2
   tier2Ids.forEach((id, i) => {
-    const p = parameters.tier2[id] as Tier2ParamRow;
+    const p = requireParams<Tier2ParamRow>(parameters.tier2, id, 2);
     const A = s.tier2[i * 2 + 0];
     const P = s.tier2[i * 2 + 1];
     const G = levers.Gs(id, t);
@@ -271,7 +298,7 @@ function derivatives(
 
   // Tier 3
   tier3Ids.forEach((id, i) => {
-    const p = parameters.tier3[id] as Tier3ParamRow;
+    const p = requireParams<Tier3ParamRow>(parameters.tier3, id, 3);
     const A = s.tier3[i];
     const G = levers.Gs(id, t);
     // dA/dt = (1-A) rho_A (gamma E + G) - A rho_A (1 - gamma E)

--- a/lib/model/schemas.ts
+++ b/lib/model/schemas.ts
@@ -20,8 +20,11 @@ export const EvidenceRecord = z.object({
 });
 export type EvidenceRecord = z.infer<typeof EvidenceRecord>;
 
+// Rate constants are bounded gain-loss coefficients and stocks in [0, 10].
+// The generous upper bound catches calibration typos (e.g. 30 instead of 0.30)
+// while leaving headroom above the current v0.3 values (all <= 1).
 const Rate = z
-  .object({ value: z.number().nonnegative() })
+  .object({ value: z.number().nonnegative().max(10) })
   .and(EvidenceRecord);
 
 export const GlobalParams = z.object({

--- a/lib/model/validate-comparison.ts
+++ b/lib/model/validate-comparison.ts
@@ -1,5 +1,14 @@
 import type { RunOverrides } from "./engine";
 
+/** Keys of the rate-multiplier override block, used for typed iteration. */
+type RateMultiplierKey = keyof NonNullable<RunOverrides["rateMultipliers"]>;
+const RATE_MULTIPLIER_KEYS: readonly RateMultiplierKey[] = [
+  "adoption",
+  "capability",
+  "productivity",
+  "labour",
+];
+
 export type ComparisonInput = {
   selectedScenarioIds: string[];
   budgetEnvelope: number;
@@ -58,15 +67,15 @@ export function validateComparison(input: ComparisonInput): ComparisonValidation
     }
 
     const m = o.rateMultipliers;
-    const labels: Record<string, string> = {
+    const labels: Record<RateMultiplierKey, string> = {
       adoption: "Adoption speed",
       capability: "Capability building",
       productivity: "Productivity sensitivity",
       labour: "Labour pressure sensitivity",
     };
     if (m) {
-      for (const key of Object.keys(labels)) {
-        const v = (m as Record<string, number | undefined>)[key];
+      for (const key of RATE_MULTIPLIER_KEYS) {
+        const v = m[key];
         if (v === undefined) continue;
         if (
           v < OVERRIDE_BOUNDS.rateMultiplier.min ||

--- a/lib/oecd-apac.ts
+++ b/lib/oecd-apac.ts
@@ -13,8 +13,9 @@
  * Observatory country dashboards when adding a new content version.
  */
 
-export type EvidenceClass = "observed" | "derived" | "expert" | "placeholder";
-export type Confidence = "low" | "medium" | "high";
+import type { Confidence, EvidenceClass } from "./model/schemas";
+
+export type { Confidence, EvidenceClass } from "./model/schemas";
 
 export interface OECDApacRow {
   /** ISO 3166-1 alpha-2 code. */

--- a/lib/reference-data.ts
+++ b/lib/reference-data.ts
@@ -1,10 +1,9 @@
-export const EVIDENCE_CLASSES = [
-  "Observed",
-  "Derived",
-  "Expert",
-  "Placeholder",
-  "Assumed"
-] as const;
+import { EvidenceClass } from "./model/schemas";
+
+/** Display labels for the evidence classes, derived from the canonical enum. */
+export const EVIDENCE_CLASSES = EvidenceClass.options.map(
+  (c) => (c.charAt(0).toUpperCase() + c.slice(1)) as Capitalize<typeof c>,
+);
 
 export type GlossaryEntry = {
   term: string;

--- a/lib/ui/theme.ts
+++ b/lib/ui/theme.ts
@@ -1,0 +1,41 @@
+// Shared visual constants for charts and legends.
+// Centralised here so tier colours, scenario palette, and labels stay
+// consistent across the baseline and compare visualisations.
+
+/** Colour per sector tier (1 = full dynamics, 2 = simplified, 3 = residual). */
+export const TIER_COLOURS: Record<1 | 2 | 3, string> = {
+  1: "#0f172a",
+  2: "#0891b2",
+  3: "#94a3b8",
+};
+
+/** Long-form tier labels for legends. */
+export const TIER_LABELS: Record<1 | 2 | 3, string> = {
+  1: "Tier 1 — full dynamics",
+  2: "Tier 2 — simplified",
+  3: "Tier 3 — residual",
+};
+
+/**
+ * Scenario line/bar palette. Index 0 (ink) is used for the first/reference
+ * series; subsequent entries cycle for the selected scenarios.
+ */
+export const SCENARIO_PALETTE = [
+  "#0f172a", // ink
+  "#0891b2", // datum
+  "#ea580c", // accent
+  "#7c3aed",
+  "#16a34a",
+] as const;
+
+/** Non-reference scenario colours (the palette without the leading ink). */
+export const SCENARIO_NON_REFERENCE = SCENARIO_PALETTE.slice(1);
+
+/** Muted grey used for the status-quo / reference series. */
+export const MUTED_COLOUR = "#94a3b8";
+
+/** Gridline colour used by SVG charts. */
+export const GRIDLINE_COLOUR = "#e2e8f0";
+
+/** Axis line colour used by SVG charts. */
+export const AXIS_COLOUR = "#0f172a";

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,18 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
+        "@vitest/coverage-v8": "^2.1.9",
         "autoprefixer": "10.4.19",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.6",
         "postcss": "8.4.39",
         "tailwindcss": "3.4.4",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -36,6 +39,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -69,6 +86,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -298,27 +316,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -329,6 +332,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1007,6 +1401,34 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1298,6 +1720,384 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1352,6 +2152,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1362,6 +2163,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1421,6 +2223,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1971,12 +2774,159 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2009,6 +2959,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -2232,6 +3195,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2399,6 +3372,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2411,6 +3385,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -2503,6 +3487,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2518,6 +3519,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2722,6 +3733,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2816,6 +3837,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.361",
@@ -2948,6 +3976,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3008,6 +4043,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3037,6 +4111,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3246,6 +4321,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3495,6 +4571,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3503,6 +4589,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3644,6 +4740,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fraction.js": {
@@ -3806,6 +4919,28 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3817,6 +4952,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3972,6 +5133,13 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4207,6 +5375,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -4454,6 +5632,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4472,12 +5704,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4662,6 +5911,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4670,6 +5926,44 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4727,6 +6021,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -5130,6 +6434,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5170,6 +6481,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5209,6 +6561,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5239,6 +6638,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -5397,6 +6797,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5406,6 +6807,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5539,6 +6941,58 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5831,6 +7285,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5847,6 +7321,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5859,6 +7347,70 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -5972,6 +7524,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -6156,6 +7748,60 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -6178,6 +7824,20 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -6220,11 +7880,42 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6389,6 +8080,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6533,6 +8225,186 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6638,6 +8510,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6646,6 +8535,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/yallist": {
@@ -6689,6 +8673,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "^16.2.6",
@@ -16,14 +19,17 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "10.4.19",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.6",
     "postcss": "8.4.39",
     "tailwindcss": "3.4.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3100;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tests/e2e/compare.spec.ts
+++ b/tests/e2e/compare.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Compare page", () => {
+  test("renders the policy lab and caveat", async ({ page }) => {
+    await page.goto("/compare");
+    await expect(
+      page.getByRole("heading", { name: "Policy scenario comparison" }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Policy lab" })).toBeVisible();
+    await expect(
+      page.getByText("Comparative signals only.", { exact: false }),
+    ).toBeVisible();
+  });
+
+  test("runs a comparison and encodes config into the URL", async ({ page }) => {
+    await page.goto("/compare");
+
+    const horizon = page.getByRole("slider", { name: "Time horizon" });
+    const runButton = page.getByRole("button", { name: /^Run simulation/ });
+
+    // Nudging the horizon makes the staged config dirty. Poll to absorb the
+    // brief window before the client component finishes hydrating.
+    await expect(async () => {
+      await horizon.focus();
+      await horizon.press("ArrowRight");
+      await expect(runButton).toBeEnabled({ timeout: 1000 });
+    }).toPass({ timeout: 15_000 });
+
+    await runButton.click();
+
+    await expect(page).toHaveURL(/[?&]h=/);
+    await expect(
+      page.getByText("Whole-economy productivity over time"),
+    ).toBeVisible();
+  });
+
+  test("copies a shareable link", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/compare");
+
+    const shareButton = page.getByRole("button", { name: "Copy share link" });
+    await expect(async () => {
+      await shareButton.click();
+      await expect(
+        page.getByRole("button", { name: "Link copied" }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15_000 });
+  });
+});

--- a/tests/e2e/explainer.spec.ts
+++ b/tests/e2e/explainer.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+const RNZ_HREF = /rnz\.co\.nz/;
+
+test.describe("How it works explainer", () => {
+  test("renders the full concept diagram", async ({ page }) => {
+    await page.goto("/how-it-works");
+    await expect(
+      page.getByRole("img", { name: /electrification analogy/i }).first(),
+    ).toBeVisible();
+  });
+
+  test("jump navigation resolves to a section anchor", async ({ page }) => {
+    await page.goto("/how-it-works");
+    const nav = page.getByRole("navigation", { name: "On this page" });
+    await expect(nav).toBeVisible();
+    await nav.getByRole("link", { name: "Why it matters now" }).click();
+    await expect(page).toHaveURL(/#why-now$/);
+    await expect(
+      page.getByRole("heading", { name: /A real productivity bet/i }),
+    ).toBeVisible();
+  });
+
+  test("worked example cites the public-sector source", async ({ page }) => {
+    await page.goto("/how-it-works");
+    await expect(
+      page.locator("#why-now").getByRole("link", { name: /RNZ/i }),
+    ).toHaveAttribute("href", RNZ_HREF);
+  });
+});
+
+test.describe("Home page", () => {
+  test("renders the compact concept diagram and the news band", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("img", { name: /electrification analogy/i }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /When productivity is banked before it arrives/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Source: RNZ/i }),
+    ).toHaveAttribute("href", RNZ_HREF);
+  });
+});

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { runComparison } from "@/lib/model/compare";
+
+describe("runComparison", () => {
+  it("always includes the status-quo reference run", () => {
+    const result = runComparison(["aggregate"], 10, 400);
+    const reference = result.scenarios.find((s) => s.isReference);
+    expect(reference).toBeDefined();
+    expect(reference?.scenarioId).toBe("status-quo");
+  });
+
+  it("reports four outcome dimensions per scenario", () => {
+    const result = runComparison(["aggregate", "targeted-demand"], 10, 400);
+    for (const s of result.scenarios) {
+      expect(s.outcomes).toHaveLength(4);
+    }
+  });
+
+  it("treats the reference run as flat against itself", () => {
+    const result = runComparison(["aggregate"], 10, 400);
+    const reference = result.scenarios.find((s) => s.isReference)!;
+    for (const o of reference.outcomes) {
+      expect(o.delta).toBeCloseTo(0, 9);
+      expect(o.direction).toBe("flat");
+    }
+  });
+
+  it("moves productivity when the budget envelope increases", () => {
+    const small = runComparison(["aggregate"], 10, 100);
+    const large = runComparison(["aggregate"], 10, 800);
+    const pBar = (r: ReturnType<typeof runComparison>) =>
+      r.scenarios.find((s) => s.scenarioId === "aggregate")!.outcomes[0]
+        .rawValue;
+    expect(large.scenarios).not.toHaveLength(0);
+    expect(pBar(large)).toBeGreaterThan(pBar(small));
+  });
+
+  it("stamps the result with the content version and horizon", () => {
+    const result = runComparison(["aggregate"], 7, 400);
+    expect(result.horizonYears).toBe(7);
+    expect(result.contentVersion).toBeTruthy();
+  });
+});

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTENT, sectorById } from "@/lib/model/content";
+
+describe("content loading and validation", () => {
+  it("loads exactly 19 ANZSIC Level 1 sectors", () => {
+    expect(CONTENT.sectors).toHaveLength(19);
+  });
+
+  it("partitions sectors into 9 Tier 1, 6 Tier 2, 4 Tier 3", () => {
+    expect(CONTENT.tier1Ids).toHaveLength(9);
+    expect(CONTENT.tier2Ids).toHaveLength(6);
+    expect(CONTENT.tier3Ids).toHaveLength(4);
+    expect(
+      CONTENT.tier1Ids.length +
+        CONTENT.tier2Ids.length +
+        CONTENT.tier3Ids.length,
+    ).toBe(19);
+  });
+
+  it("has GDP weights that sum to approximately 1", () => {
+    const total = CONTENT.sectors.reduce((acc, s) => acc + s.gdpWeight, 0);
+    expect(total).toBeCloseTo(1, 2);
+  });
+
+  it("keeps every initial adoption value within [0, 1]", () => {
+    for (const s of CONTENT.sectors) {
+      expect(s.gdpWeight).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("resolves sectors by id and throws on unknown ids", () => {
+    const first = CONTENT.sectors[0];
+    expect(sectorById(first.id)).toBe(first);
+    expect(() => sectorById("not-a-real-sector")).toThrow(/Unknown sector id/);
+  });
+
+  it("includes the status-quo reference scenario", () => {
+    expect(CONTENT.scenarios.some((s) => s.id === "status-quo")).toBe(true);
+  });
+});

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTENT } from "@/lib/model/content";
+import { runScenario, type Trajectory } from "@/lib/model/engine";
+import type { PolicyScenario } from "@/lib/model/schemas";
+
+function scenario(id: string): PolicyScenario {
+  const s = CONTENT.scenarios.find((sc) => sc.id === id);
+  if (!s) throw new Error(`missing test scenario ${id}`);
+  return s;
+}
+
+function allStates(traj: Trajectory): number[] {
+  const xs: number[] = [...traj.E];
+  traj.tier1.forEach((r) => xs.push(...r.K, ...r.A, ...r.P, ...r.L));
+  traj.tier2.forEach((r) => xs.push(...r.A, ...r.P));
+  traj.tier3.forEach((r) => xs.push(...r.A));
+  return xs;
+}
+
+describe("engine RK4 integration", () => {
+  it("emits one snapshot per year plus the initial state", () => {
+    const traj = runScenario(scenario("aggregate"), 10, undefined);
+    expect(traj.times).toHaveLength(11);
+    expect(traj.times[0]).toBe(0);
+    expect(traj.times.at(-1)).toBeCloseTo(10, 6);
+  });
+
+  it("keeps every state variable within [0, 1]", () => {
+    const traj = runScenario(scenario("aggregate"), 15, undefined);
+    for (const x of allStates(traj)) {
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const a = runScenario(scenario("targeted-demand"), 10, undefined);
+    const b = runScenario(scenario("targeted-demand"), 10, undefined);
+    expect(allStates(a)).toEqual(allStates(b));
+  });
+
+  it("reproduces the calibrated run when overrides are all 1.0", () => {
+    const base = runScenario(scenario("aggregate"), 10, undefined);
+    const withUnitMultipliers = runScenario(scenario("aggregate"), 10, {
+      rateMultipliers: {
+        adoption: 1,
+        capability: 1,
+        productivity: 1,
+        labour: 1,
+      },
+    });
+    expect(allStates(withUnitMultipliers)).toEqual(allStates(base));
+  });
+
+  it("produces structures sized to the tier partition", () => {
+    const traj = runScenario(scenario("status-quo"), 5, undefined);
+    expect(traj.tier1).toHaveLength(CONTENT.tier1Ids.length);
+    expect(traj.tier2).toHaveLength(CONTENT.tier2Ids.length);
+    expect(traj.tier3).toHaveLength(CONTENT.tier3Ids.length);
+  });
+});

--- a/tests/unit/validate-comparison.test.ts
+++ b/tests/unit/validate-comparison.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { validateComparison } from "@/lib/model/validate-comparison";
+
+const validInput = {
+  selectedScenarioIds: ["aggregate"],
+  budgetEnvelope: 400,
+  horizonYears: 10,
+};
+
+describe("validateComparison", () => {
+  it("accepts a well-formed comparison", () => {
+    const result = validateComparison(validInput);
+    expect(result.comparable).toBe(true);
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it("rejects an empty scenario selection", () => {
+    const result = validateComparison({
+      ...validInput,
+      selectedScenarioIds: [],
+    });
+    expect(result.comparable).toBe(false);
+    expect(result.messages.join(" ")).toMatch(/at least one scenario/i);
+  });
+
+  it("rejects a non-positive budget envelope", () => {
+    const result = validateComparison({ ...validInput, budgetEnvelope: 0 });
+    expect(result.comparable).toBe(false);
+    expect(result.messages.join(" ")).toMatch(/budget envelope/i);
+  });
+
+  it("rejects a horizon outside 1-20 years", () => {
+    expect(validateComparison({ ...validInput, horizonYears: 0 }).comparable).toBe(
+      false,
+    );
+    expect(validateComparison({ ...validInput, horizonYears: 25 }).comparable).toBe(
+      false,
+    );
+  });
+
+  it("flags rate multipliers outside [0.5, 1.5]", () => {
+    const result = validateComparison({
+      ...validInput,
+      overrides: { rateMultipliers: { adoption: 2 } },
+    });
+    expect(result.comparable).toBe(false);
+    expect(result.messages.join(" ")).toMatch(/adoption speed/i);
+  });
+
+  it("flags an out-of-range demand vs supply split", () => {
+    const result = validateComparison({
+      ...validInput,
+      overrides: { demandSupplySplit: 1.5 },
+    });
+    expect(result.comparable).toBe(false);
+    expect(result.messages.join(" ")).toMatch(/demand vs supply/i);
+  });
+
+  it("accepts in-range overrides", () => {
+    const result = validateComparison({
+      ...validInput,
+      overrides: {
+        leverDurationYears: 5,
+        demandSupplySplit: 0.5,
+        rateMultipliers: { adoption: 1.2, labour: 0.8 },
+      },
+    });
+    expect(result.comparable).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+const rootDir = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": rootDir.replace(/\/$/, ""),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["lib/model/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Bundles the testing framework introduction with the explainer electrification-analogy work and the comparison-workspace landing-experience improvements.

### Testing
- Add Vitest (unit) and Playwright (e2e) with config and CI workflow.
- Unit tests for comparison logic, content loading, engine behaviour, and validation.
- e2e tests for the Compare page and How-it-works explainer.

### Explainer / analogy consistency
- Consistent electrification / national-grid analogy across home, how-it-works, and the shared concept diagram (no residual road/traffic metaphor).
- New shared `system-diagram`, `on-this-page` jump-nav, and `chart-legend` components.

### Comparison workspace landing UX
- "Now showing" summary line that states what is currently rendered, with a jump-to-results anchor.
- Always-on status-quo reference chip so the like-for-like framing is visible.
- Fixed the dead primary CTA on arrival (clearer "Results up to date" state + live "View results" link).
- Empty-state placeholder inside a `#results` anchor when selections aren't comparable.

## Verification
- `npm run typecheck`, `npm run lint`, `npm run build` all clean.
- 23 unit tests + 7 e2e tests passing.

## Notes
Comparative-not-predictive framing preserved; NZ English and spaced-hyphen style followed.